### PR TITLE
Fix bsc#1062267

### DIFF
--- a/SAPHanaSR.changes
+++ b/SAPHanaSR.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Oct 23 11:46:24 UTC 2017 - imanyugin@suse.com
+
+- Fix bsc#1062267: SAPHanaSR wizard sets IPAddr2 agent's NIC to eth0
+
+-------------------------------------------------------------------
 Thu Jul 06 12:12:21 UTC 2017 - imanyugin@suse.com
 
 - Fix bsc#1045606: update man pages

--- a/wizard/hawk2/saphanasr.yaml
+++ b/wizard/hawk2/saphanasr.yaml
@@ -155,7 +155,6 @@
           params
           ip="{{IP}}"
           cidr_netmask={{netmask}}
-          nic=eth0
           op start timeout=20 op stop timeout=20 op monitor interval=10 timeout=20
         
         primitive rsc_SAPHana_{{System_ID}}_HDB{{Instance}} ocf:suse:SAPHana


### PR DESCRIPTION
Fix bsc#1062267 - SAPHanaSR HAWK2 wizard sets IPAddr2 agent's NIC to `eth0` by default