### PR TITLE
SAPHanaTopology - Fix from upstream: 6c6489a63e7e354bb97dfb9fcc833954…

### DIFF
--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -566,7 +566,7 @@ function sht_init() {
     siteID=$(echo "$hdbANSWER" | awk -F= '/site.id/ {print $2}')       # allow 'site_id' AND 'site id'
     siteNAME=$(echo "$hdbANSWER" | awk -F= '/site.name/ {print $2}')
     site=$siteNAME
-    srmode=$(echo "$hdbANSWER" | awk -F= '/mode/ {print $2}')
+    srmode=$(echo "$hdbANSWER" | awk -F= '$1=="mode" {print $2}')
     #
     # for rev >= 111 we use the new mapping query
     #


### PR DESCRIPTION
SAPHanaTopology: Stronger matching of 'mode' in awk statement