### PR TITLE
Version bump to 0.152.22

### DIFF
--- a/SAPHanaSR.changes
+++ b/SAPHanaSR.changes
@@ -1,6 +1,7 @@
 -------------------------------------------------------------------
 Fri May 18 14:31:16 UTC 2018 - imanyugin@suse.com
 
+- Version bump to 0.152.22
 - Fix bsc#1091074:
     + Adjust Perl scripts to Perl 5.26.0
     + Remove show_SAPHanaSR_attributes

--- a/SAPHanaSR.spec
+++ b/SAPHanaSR.spec
@@ -20,7 +20,7 @@ License:        GPL-2.0
 Group:          Productivity/Clustering/HA
 AutoReqProv:    on
 Summary:        Resource agents to control the HANA database in system replication setup
-Version:        0.152.21
+Version:        0.152.22
 Release:        0
 Url:            http://scn.sap.com/community/hana-in-memory/blog/2014/04/04/fail-safe-operation-of-sap-hana-suse-extends-its-high-availability-solution
 

--- a/man/SAPHanaSR-monitor.8
+++ b/man/SAPHanaSR-monitor.8
@@ -1,4 +1,4 @@
-.\" Version: 0.152.21
+.\" Version: 0.152.22
 .\"
 .TH SAPHanaSR-monitor 8 "02 Feb 2017" "" "SAPHanaSR"
 .\"

--- a/man/SAPHanaSR-showAttr.8
+++ b/man/SAPHanaSR-showAttr.8
@@ -1,4 +1,4 @@
-.\" Version: 0.152.21
+.\" Version: 0.152.22
 .\"
 .TH SAPHanaSR-showAttr 8 "02 Feb 2017" "" "SAPHanaSR"
 .\"

--- a/man/SAPHanaSR.7
+++ b/man/SAPHanaSR.7
@@ -1,4 +1,4 @@
-.\" Version: 0.152.21
+.\" Version: 0.152.22
 .\"
 .TH SAPHanaSR 7 "10 Feb 2017" "" "SAPHanaSR"
 .\"

--- a/man/ocf_suse_SAPHana.7
+++ b/man/ocf_suse_SAPHana.7
@@ -1,4 +1,4 @@
-.\" Version: 0.152.21
+.\" Version: 0.152.22
 .\"
 .TH ocf_suse_SAPHana 7 "14 Jun 2017" "" "OCF resource agents"
 .\"

--- a/man/ocf_suse_SAPHanaTopology.7
+++ b/man/ocf_suse_SAPHanaTopology.7
@@ -1,4 +1,4 @@
-.\" Version: 0.152.21
+.\" Version: 0.152.22
 .\"
 .TH ocf_suse_SAPHanaTopology 7 "02 Feb 2017" "" "OCF resource agents"
 .\"

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -35,7 +35,7 @@
 #######################################################################
 #
 # Initialization:
-SAPHanaVersion="0.152.21"
+SAPHanaVersion="0.152.22"
 timeB=$(date '+%s')
 
 : ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -28,7 +28,7 @@
 #######################################################################
 #
 # Initialization:
-SAPHanaVersion="0.152.21"
+SAPHanaVersion="0.152.22"
 timeB=$(date '+%s')
 
 : ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}


### PR DESCRIPTION
This is to bump version to 0.152.22 and re-submit the MR to all supported platforms.