### PR TITLE
Include HANA_CALL retries until the limit of the operation timeout

### DIFF
--- a/SAPHanaSR.changes
+++ b/SAPHanaSR.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Jun 11 11:28:16 UTC 2019 - dakechi@suse.com
+
+- Version bump to 0.152.23
+  * Include retries into the HANA_CALL until the limit of the
+    configured resource operation timeout. This avoids that
+    HANA_CALL returns RC 124 and cause unlogged failovers.
+    (bsc#1134106, bsc#1133024, bsc#1101373)
+
+-------------------------------------------------------------------
 Fri May 18 14:31:16 UTC 2018 - imanyugin@suse.com
 
 - Version bump to 0.152.22
@@ -36,13 +45,13 @@ Fri May 26 07:51:51 UTC 2017 - imanyugin@suse.com
 -------------------------------------------------------------------
 Wed May  3 11:38:06 UTC 2017 - imanyugin@suse.com
 
-- Fix bsc#1034685: SAPHanaTopology fails once after updating to 0.152.20 
+- Fix bsc#1034685: SAPHanaTopology fails once after updating to 0.152.20
 
 -------------------------------------------------------------------
 Wed Feb 15 11:09:18 UTC 2017 - imanyugin@suse.com
 
 - Version bump to 0.152.20
-- Fix bsc#1019117: Fix master scoring of secondary during a takeover 
+- Fix bsc#1019117: Fix master scoring of secondary during a takeover
 
 -------------------------------------------------------------------
 Tue Dec 20 10:47:57 UTC 2016 - ilya.manyugin@suse.com
@@ -119,7 +128,7 @@ Mon Jun 29 09:38:12 UTC 2015 - fabian.herschel@suse.com
 
 - Fix for bsc#935755; SAPHanaSR together with DAA-SAP-Instance does not work as expected
 - Fix for bsc#936387; SAPHanaSR fails to work with multi tenant databases
-- Fix for bsc#919925; SAPHanaSR: Leaving Node Maintenance stops HANA Resource Agent 
+- Fix for bsc#919925; SAPHanaSR: Leaving Node Maintenance stops HANA Resource Agent
 
 -------------------------------------------------------------------
 Mon Dec  8 16:17:50 UTC 2014 - fabian.herschel@suse.com
@@ -132,8 +141,8 @@ Mon Dec  8 16:17:50 UTC 2014 - fabian.herschel@suse.com
 Tue Nov  4 15:08:47 UTC 2014 - fabian.herschel@suse.com
 
 - Package version 0.149;
-- Fix for bnc#902244; SAPHanaSR fails when hdbnsutil does not return correctly or does report incomplete output 
-- Fix for bnc#902241; SAPHanaSR fails in cold bootstrap 
+- Fix for bnc#902244; SAPHanaSR fails when hdbnsutil does not return correctly or does report incomplete output
+- Fix for bnc#902241; SAPHanaSR fails in cold bootstrap
 - Updated Setup-Guide 11/04/2014
 
 -------------------------------------------------------------------

--- a/SAPHanaSR.spec
+++ b/SAPHanaSR.spec
@@ -20,7 +20,7 @@ License:        GPL-2.0
 Group:          Productivity/Clustering/HA
 AutoReqProv:    on
 Summary:        Resource agents to control the HANA database in system replication setup
-Version:        0.152.22
+Version:        0.152.23
 Release:        0
 Url:            http://scn.sap.com/community/hana-in-memory/blog/2014/04/04/fail-safe-operation-of-sap-hana-suse-extends-its-high-availability-solution
 
@@ -47,10 +47,10 @@ Summary:        Setup Guide for SAPHanaSR
 Group:          Productivity/Clustering/HA
 
 %description
-The resource agents SAPHana and SAPHanaTopology are responsible for controlling 
+The resource agents SAPHana and SAPHanaTopology are responsible for controlling
 a SAP HANA Database which is running in system replication (SR) configuration.
 
-For SAP HANA Databases in System Replication only the described or referenced scenarios in 
+For SAP HANA Databases in System Replication only the described or referenced scenarios in
 the README file of this package are supported. For any scenario not matching the scenarios
 named or referenced in the README file please contact SUSE at SAP LinuxLab (sap-lab@suse.de).
 
@@ -64,7 +64,7 @@ Authors:
 
 
 %description doc
-This subpackage includes the Setup Guide and manual pages for getting 
+This subpackage includes the Setup Guide and manual pages for getting
 SAP HANA system replication under cluster control.
 
 
@@ -105,7 +105,7 @@ install -m 0555 test/SAPHanaSR-monitor %{buildroot}/usr/sbin
 install -m 0555 test/SAPHanaSR-showAttr %{buildroot}/usr/sbin
 install -m 0444 test/SAPHanaSRTools.pm %{buildroot}/usr/lib/%{name}
 
-# crm/hawk wizard files 
+# crm/hawk wizard files
 %if 0%{?sle_version} >= 120100
 # SLES 12 SP1+ and HAWK2
 install -D -m 0644 wizard/hawk2/saphanasr.yaml %{buildroot}%{crmscr_path}/saphanasr/main.yml

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -35,7 +35,7 @@
 #######################################################################
 #
 # Initialization:
-SAPHanaVersion="0.152.22"
+SAPHanaVersion="0.152.23"
 timeB=$(date '+%s')
 
 : ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}
@@ -1445,7 +1445,7 @@ function saphana_start_primary()
             if [ -z "$my_role" ]; then
                 my_role=$(get_hana_attribute ${NODENAME} ${ATTR_NAME_HANA_ROLES[@]})
             fi
-            super_ocf_log info "SCORE: saphana_start_primary: scoring_crm_master($my_role,$my_sync)" 
+            super_ocf_log info "SCORE: saphana_start_primary: scoring_crm_master($my_role,$my_sync)"
             scoring_crm_master "$my_role" "$my_sync"
             ;;
         register ) # process a REGISTER
@@ -2140,7 +2140,7 @@ function saphana_monitor_primary()
                         #super_ocf_log info "DEC: PreferSiteTakeover selected so decrease promotion score here"
                         my_role=$(get_hana_attribute ${NODENAME} ${ATTR_NAME_HANA_ROLES[@]})
                         my_sync=$(get_hana_attribute ${NODENAME} ${ATTR_NAME_HANA_SYNC_STATUS[@]})
-                        super_ocf_log info "SCORE: saphana_monitor_primary: scoring_crm_master($my_role,$my_sync)" 
+                        super_ocf_log info "SCORE: saphana_monitor_primary: scoring_crm_master($my_role,$my_sync)"
                         scoring_crm_master "$my_role" "$my_sync"
                         rc=$OCF_FAILED_MASTER
                     fi
@@ -2203,7 +2203,7 @@ function saphana_monitor_primary()
                           ;;
                    esac
                 fi
-                super_ocf_log info "SCORE: saphana_monitor_primary: scoring_crm_master($my_role,$my_sync)" 
+                super_ocf_log info "SCORE: saphana_monitor_primary: scoring_crm_master($my_role,$my_sync)"
                 scoring_crm_master "$my_role" "$my_sync"
             fi
             ;;
@@ -2314,7 +2314,7 @@ function saphana_monitor_secondary()
                     super_ocf_log info "DEC: secondary with sync status SOK ==> possible takeover node"
                     my_role=$(get_hana_attribute ${NODENAME} ${ATTR_NAME_HANA_ROLES[@]})
                     my_sync=$(get_hana_attribute ${NODENAME} ${ATTR_NAME_HANA_SYNC_STATUS[@]})
-                    super_ocf_log info "SCORE: saphana_monitor_secondary: scoring_crm_master($my_role,$my_sync)" 
+                    super_ocf_log info "SCORE: saphana_monitor_secondary: scoring_crm_master($my_role,$my_sync)"
                     scoring_crm_master "$my_role" "$my_sync"
                     ;;
                 "SFAIL" ) # This is currently NOT a possible node to promote

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -28,7 +28,7 @@
 #######################################################################
 #
 # Initialization:
-SAPHanaVersion="0.152.22"
+SAPHanaVersion="0.152.23"
 timeB=$(date '+%s')
 
 : ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}


### PR DESCRIPTION
Include retries on the HANA_CALL until the limit of the configured operation timeout. In case of timeout, it will return a` $OCF_ERR_GENERIC` return code, and not the timeout return code 124.