### PR TITLE
SAPHana: Gap between released hanging commits and SFAIL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SAP HANA System Replication (Scale-Up) old fmherschel private repo - use SUSE/SAPHanaSR instead
+# SAP HANA System Replication (Scale-Up)
 
 ## File structure
 


### PR DESCRIPTION
See also bsc#1139715 - SAPHanaSR: Gap between released hanging commits and SFAIL detection could force data loss

The fix allows to come more reliant back also during a hanging systemRepplicationStatus.py and
to mark SFAIL due to the timeout (124) or signal (128+sig) return codes.