### PR TITLE
SAPHana: possible fix for bsc#1133866

### DIFF
--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -2157,7 +2157,11 @@ function saphana_monitor_primary()
             ;;
         2 | 3 | 4 ) # WARN, INFO or OK
             if ocf_is_probe; then
-                rc=$OCF_SUCCESS
+                if [ "$promoted" -eq 1 ]; then
+                    rc=$OCF_RUNNING_MASTER
+                else
+                    rc=$OCF_SUCCESS
+                fi
             else
                 LPTloc=$(date '+%s')
                 lpa_set_lpt $LPTloc $NODENAME


### PR DESCRIPTION
Return $OCF_RUNNING_MASTER (8) instead of $OCF_SUCCESS (0)
when probing a promoted node.