### PR TITLE
SAPHanaSR-monitor: Solving side effect from regular expression parsing

### DIFF
--- a/test/SAPHanaSR-monitor
+++ b/test/SAPHanaSR-monitor
@@ -5,7 +5,7 @@
 # (c) 2015-2016 SUSE Linux GmbH, Nuremberg, Germany
 # Author: Fabian Herschel <fabian.herschel@suse.com>
 # License: GPL v2+
-my $Version="0.22.2019.27-08.1";
+my $Version="0.23.2019.09.04.1";
 #
 ##################################################################
 use POSIX;
@@ -112,12 +112,21 @@ sub  print_page
   my $nextNr; my $prevNr; my $prevUrl;
   if ( $format = "html2" ) {
      my $Nr=0;
+     my $FirstPart="";
+     my $LastPart="";
      if ( $HtmlPage =~ /(.*\.)([0-9]+)(\.html)/ ) {
-         $Nr = $2 ;
+         $FirstPart = $1;
+         $Nr = $2;
+         $LastPart  = $3;
+         #
+         # remove path from url
+         #
+         $FirstPart =~ s/\/.*\/([^\/]*)$/.\/$1/ ;
          $nextNr = $Nr + 1;
          $prevNr = $Nr - 1;
-         $nextUrl="$1" . "$nextNr" . "$3"; $nextUrl =~ s/\/.*\/([^\/]*)$/.\/$1/  ;
-         $prevUrl="$1" . "$prevNr" . "$3"; $prevUrl =~ s/\/.*\/([^\/]*)$/.\/$1/  ;
+         if ( $prevNr < 0 ) { $prevNr = 0; }
+         $nextUrl="$FirstPart" . "$nextNr" . "$LastPart";
+         $prevUrl="$FirstPart" . "$prevNr" . "$LastPart";
      }
   }
   if ($format eq "txt") {


### PR DESCRIPTION
in addition also solved the "previous" page of the first frame. Now previous of the first page points to itself. For the last page we loop back to the first frame. I know this is different, but in the single SAPHanaSR-monitor call I do not know the neighborhood frames. 