### PR TITLE
fix documented defaults for some Parameters to match code

### DIFF
--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -216,7 +216,7 @@ The resource agent uses the following four interfaces provided by SAP:
         <content type="string" default="" />
     </parameter>
     <parameter name="PREFER_SITE_TAKEOVER" unique="0" required="0">
-        <longdesc lang="en">Should cluster/RA prefer to switchover to slave instance instead of restarting master locally? Default="yes"
+        <longdesc lang="en">Should cluster/RA prefer to switchover to slave instance instead of restarting master locally? Default="false"
         no: Do prefer restart locally
         yes: Do prefer takever to remote site
         never: Do never run a sr_takeover (promote) at the secondary side. THIS VALUE IS CURRENTLY NOT SUPPORTED.

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -222,7 +222,7 @@ The resource agent uses the following four interfaces provided by SAP:
         never: Do never run a sr_takeover (promote) at the secondary side. THIS VALUE IS CURRENTLY NOT SUPPORTED.
         </longdesc>
         <shortdesc lang="en">Local or site recover preferred?</shortdesc>
-        <content type="string" default="yes" />
+        <content type="string" default="false" />
     </parameter>
     <parameter name="AUTOMATED_REGISTER"  unique="0" required="0">
         <shortdesc lang="en">Define, if a former primary should automatically be registered.</shortdesc>
@@ -248,7 +248,7 @@ The resource agent uses the following four interfaces provided by SAP:
           If the timeout is reached, the return code will be 124. If you increase the timeouts for HANA calls you should also adjust the operation timeouts
           of your cluster resources.
         </longdesc>
-        <content type="string" default="120" />
+        <content type="string" default="60" />
     </parameter>
     <parameter name="DIR_EXECUTABLE" unique="0" required="0">
         <longdesc lang="en">The full qualified path where to find sapstartsrv and sapcontrol. Specify this parameter, if you have changed the SAP kernel directory location after the default SAP installation.</longdesc>


### PR DESCRIPTION
PREFER_SITE_TAKEOVER default in code is actually 'false' if not explicitly set; this change was actually discussed in the old upstream repo a long time agi, but never implemented
HANA_CALL_TIMEOUT default is currently hardcoded to 60s