### PR TITLE
srHook SAPHanaSR ScaleUp - log empty site names (bsc#1173581)

### DIFF
--- a/SAPHanaSR.changes_12
+++ b/SAPHanaSR.changes_12
@@ -1,4 +1,15 @@
 -------------------------------------------------------------------
+Thu Jul  2 11:27:34 UTC 2020 - abriel@suse.com
+
+- Version bump to 0.154.1
+- log empty site names, but do not generate bad formatted cluster
+  attribute name
+  (bsc#1173581)
+- fix documentation of some parameter defaults
+- adjust start/stop/promote/monitor action timeouts to match
+  official recommendations
+
+-------------------------------------------------------------------
 Thu Nov 21 12:50:07 UTC 2019 - abriel@suse.com
 
 - restart sapstartsrv service on master nameserver node during

--- a/SAPHanaSR.changes_15
+++ b/SAPHanaSR.changes_15
@@ -1,4 +1,15 @@
 -------------------------------------------------------------------
+Thu Jul  2 11:27:34 UTC 2020 - abriel@suse.com
+
+- Version bump to 0.154.1
+- log empty site names, but do not generate bad formatted cluster
+  attribute name
+  (bsc#1173581)
+- fix documentation of some parameter defaults
+- adjust start/stop/promote/monitor action timeouts to match
+  official recommendations
+
+-------------------------------------------------------------------
 Thu Nov 21 12:50:07 UTC 2019 - abriel@suse.com
 
 - restart sapstartsrv service on master nameserver node during

--- a/SAPHanaSR.spec
+++ b/SAPHanaSR.spec
@@ -3,7 +3,7 @@
 #
 # Copyright (c) 2013-2014 SUSE Linux Products GmbH, Nuernberg, Germany.
 # Copyright (c) 2014-2016 SUSE Linux GmbH, Nuernberg, Germany.
-# Copyright (c) 2017-2019 SUSE LLC.
+# Copyright (c) 2017-2020 SUSE LLC.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -21,7 +21,7 @@ License:        GPL-2.0
 Group:          Productivity/Clustering/HA
 AutoReqProv:    on
 Summary:        Resource agents to control the HANA database in system replication setup
-Version:        0.154.0
+Version:        0.154.1
 Release:        0
 Url:            http://scn.sap.com/community/hana-in-memory/blog/2014/04/04/fail-safe-operation-of-sap-hana-suse-extends-its-high-availability-solution
 

--- a/srHook/SAPHanaSR.py
+++ b/srHook/SAPHanaSR.py
@@ -15,7 +15,7 @@ similar) to your global.ini:
     [trace]
     ha_dr_saphanasr = info
 """
-fhSRHookVersion = "0.161.0"
+fhSRHookVersion = "0.162.0"
 
 
 class SAPHanaSR(HADRBase):
@@ -92,19 +92,22 @@ class SAPHanaSR(HADRBase):
         myInSync = ParamDict["is_in_sync"]
         myReason = ParamDict["reason"]
         mySite = ParamDict["siteName"]
-        if (mySystemStatus == 15):
+        if mySystemStatus == 15:
             mySRS = "SOK"
         else:
-            if (myInSync):
+            if myInSync:
                 # ignoring the SFAIL, because we are still in sync
                 self.tracer.info("SAPHanaSR (%s) %s.srConnectionChanged ignoring bad SR status because of is_in_sync=True (reason=%s)" % (fhSRHookVersion, self.__class__.__name__, myReason))
                 mySRS = ""
             else:
                 mySRS = "SFAIL"
-        if (mySRS == ""):
+        if mySRS == "":
             self.tracer.info("SAPHanaSR (%s) 001" % (self.__class__.__name__))
             myMSG = "### Ignoring bad SR status because of is_in_sync=True ###"
             self.tracer.info("SAPHanaSR (%s) 002" % (self.__class__.__name__))
+        elif mySite == "":
+            myMSG = "### Ignoring bad SR status because of empty site name in call params ###"
+            self.tracer.info("SAPHanaSR (%s) was called with empty site name. Ignoring call." % (self.__class__.__name__))
         else:
             myCMD = "sudo /usr/sbin/crm_attribute -n hana_%s_site_srHook_%s -v %s -t crm_config -s SAPHanaSR" % (mysid, mySite, mySRS)
             rc = os.system(myCMD)


### PR DESCRIPTION
During a SR takeover there may be a small time frame where the srHook gets a state change from the API with an empty site name. So log the occurrence of the empty site names, but do not generate bad formatted cluster attribute name.
Take the coding from the SAPHanaSR-ScaleOut Hook implementation.