### PR TITLE
bsc#1182545 - make action start/stop timeouts configurable

### DIFF
--- a/SAPHanaSR.changes_12
+++ b/SAPHanaSR.changes_12
@@ -1,4 +1,21 @@
 -------------------------------------------------------------------
+Thu Mar  4 18:29:15 UTC 2021 - abriel@suse.com
+
+- Version bump to 0.155.0
+- The resource start and stop timeout is now configurable by
+  increasing the timeout for the action 'start' and/or 'stop'.
+  We will use 95% of this action timeouts to calculate the new
+  resource start and stop timeout for the 'WaitforStarted' and
+  'WaitforStopped' functions. If the new, calculated timeout value
+  is less than '3600', it will be set to '3600', so that we do not
+  decrease this timeout by accident
+  (bsc#1182545)
+- change promotion scoring during maintenance procedure to prevent
+  that both sides have an equal promotion scoring after refresh
+  which might result in a critical promotion of the secondary.
+  (bsc#1174557)
+
+-------------------------------------------------------------------
 Thu Jul  2 11:27:34 UTC 2020 - abriel@suse.com
 
 - Version bump to 0.154.1

--- a/SAPHanaSR.changes_15
+++ b/SAPHanaSR.changes_15
@@ -1,4 +1,21 @@
 -------------------------------------------------------------------
+Thu Mar  4 18:29:41 UTC 2021 - abriel@suse.com
+
+- Version bump to 0.155.0
+- The resource start and stop timeout is now configurable by
+  increasing the timeout for the action 'start' and/or 'stop'.
+  We will use 95% of this action timeouts to calculate the new
+  resource start and stop timeout for the 'WaitforStarted' and
+  'WaitforStopped' functions. If the new, calculated timeout value
+  is less than '3600', it will be set to '3600', so that we do not
+  decrease this timeout by accident
+  (bsc#1182545)
+- change promotion scoring during maintenance procedure to prevent
+  that both sides have an equal promotion scoring after refresh
+  which might result in a critical promotion of the secondary.
+  (bsc#1174557)
+
+-------------------------------------------------------------------
 Thu Jul  2 11:27:34 UTC 2020 - abriel@suse.com
 
 - Version bump to 0.154.1

--- a/SAPHanaSR.spec
+++ b/SAPHanaSR.spec
@@ -21,7 +21,7 @@ License:        GPL-2.0
 Group:          Productivity/Clustering/HA
 AutoReqProv:    on
 Summary:        Resource agents to control the HANA database in system replication setup
-Version:        0.154.1
+Version:        0.155.0
 Release:        0
 Url:            http://scn.sap.com/community/hana-in-memory/blog/2014/04/04/fail-safe-operation-of-sap-hana-suse-extends-its-high-availability-solution
 
@@ -33,6 +33,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 Requires:       pacemaker > 1.1.1
 Requires:       resource-agents
+Requires:       perl
 
 # Require crmsh-scripts on SLES 12 SP1+ for the new HAWK wizards
 %if 0%{?sle_version} >= 120100
@@ -66,8 +67,7 @@ Authors:
 
 
 %description doc
-This subpackage includes the Setup Guide and manual pages for getting
-SAP HANA system replication under cluster control.
+This subpackage includes the Setup Guide for getting SAP HANA system replication under cluster control.
 
 
 %prep
@@ -180,6 +180,5 @@ install -m 0444 wizard/hawk1/90-SAPHanaSR.xml  %{buildroot}/srv/www/hawk/config/
 %doc %{_mandir}/man8/SAPHanaSR-monitor.8.gz
 %doc %{_mandir}/man8/SAPHanaSR-showAttr.8.gz
 %doc %{_mandir}/man8/SAPHanaSR-replay-archive.8.gz
-
 
 %changelog

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -391,12 +391,18 @@ function remoteHost2remoteNode()
 function get_action_timeout() {
     super_ocf_log info "FLOW $FUNCNAME ($*)"
     # $OCF_RESKEY_CRM_meta_timeout is the timeout of the current running action in ms
-    local actionTimeOut="${OCF_RESKEY_CRM_meta_timeout:-$HANA_STD_ACTION_TIMEOUT}"
+    local actionTimeOut="$OCF_RESKEY_CRM_meta_timeout"
     local stdTimeOut="$HANA_STD_ACTION_TIMEOUT"
     local actTimeOutPercent=95 # 95% to left 5% for the rest of the resource agent action
+    if [ -z "$actionTimeOut" ]; then
+        actionTimeOut="$stdTimeOut"
+    else
+        # actionTimeOut in seconds
+        ((actionTimeOut = actionTimeOut/1000))
+    fi
 
     # 95%(actionTimeOut)
-    ((timeout = actionTimeOut * actTimeOutPercent/1000))
+    ((timeout = actionTimeOut * actTimeOutPercent/100))
     # max(3600, 95%(actionTimeOut))
     if [ -z "$timeout" ] || [ "$timeout" -lt "$stdTimeOut" ]; then
         timeout=$stdTimeOut

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -39,7 +39,7 @@
 #     systemReplicationStatus.py (>= SPS090)
 #
 #######################################################################
-SAPHanaVersion="0.154.0"
+SAPHanaVersion="0.155.0"
 #
 # Initialization:
 timeB=$(date '+%s')
@@ -62,6 +62,7 @@ HANA_STATE_SECONDARY=1
 HANA_STATE_STANDALONE=2
 HANA_STATE_DEFECT=3
 HANA_CALL_TIMEOUT=60
+HANA_STD_ACTION_TIMEOUT=3600
 
 debug_attributes=0
 
@@ -315,7 +316,7 @@ function dequote()
     local rc=0; tr -d '"'; return $rc
 }
 
-# function: version: cpmpare two HANA version strings
+# function: version: compare two HANA version strings
 function ver_lt() {
     ocf_version_cmp $1 $2
     test $? -eq 0 && return 0 || return 1
@@ -336,7 +337,7 @@ function ver_ge() {
     test $? -eq 2 -o $? -eq 1 && return 0 || return 1
 }
 #
-# function: version: cpmpare two HANA version strings
+# function: version: compare two HANA version strings
 #
 function version() {
     if [ $# -eq 3 ]; then
@@ -380,6 +381,29 @@ function remoteHost2remoteNode()
     fi
     super_ocf_log info "FLOW $FUNCNAME rc=$rc"
     return $rc
+}
+
+# function: get_action_timeout
+# output:  action timeout
+#
+# timeOut = max(3600, 95%(actionTimeOut))
+#
+function get_action_timeout() {
+    super_ocf_log info "FLOW $FUNCNAME ($*)"
+    # $OCF_RESKEY_CRM_meta_timeout is the timeout of the current running action in ms
+    local actionTimeOut="${OCF_RESKEY_CRM_meta_timeout:-$HANA_STD_ACTION_TIMEOUT}"
+    local stdTimeOut="$HANA_STD_ACTION_TIMEOUT"
+    local actTimeOutPercent=95 # 95% to left 5% for the rest of the resource agent action
+
+    # 95%(actionTimeOut)
+    ((timeout = actionTimeOut * actTimeOutPercent/1000))
+    # max(3600, 95%(actionTimeOut))
+    if [ -z "$timeout" ] || [ "$timeout" -lt "$stdTimeOut" ]; then
+        timeout=$stdTimeOut
+    fi
+    super_ocf_log info "actionTimeout: action timeout was '$actionTimeOut', now changed to '$timeout'"
+    super_ocf_log info "FLOW $FUNCNAME"
+    echo $timeout
 }
 
 #
@@ -1331,8 +1355,9 @@ function saphana_start() {
     fi
     if [ $rc -eq 0 ]
     then
-        # TODO: PRIO9: something more dynamic than 3600 seconds in WaitforStarted
-        output=$($SAPCONTROL -nr $InstanceNr -function WaitforStarted 3600 1)
+        # DONE: PRIO9: something more dynamic than 3600 seconds in WaitforStarted
+        HANA_ACTION_TIMEOUT=$(get_action_timeout)
+        output=$($SAPCONTROL -nr $InstanceNr -function WaitforStarted $HANA_ACTION_TIMEOUT 1)
         if [ $? -eq 0 ]
         then
             super_ocf_log info "ACT: SAPHANA Instance $SID-$InstanceName started: $output"
@@ -1367,7 +1392,8 @@ function saphana_stop() {
   fi
   if [ $rc -eq 0 ]
   then
-    output=$($SAPCONTROL -nr $InstanceNr -function WaitforStopped 3600 1)
+    HANA_ACTION_TIMEOUT=$(get_action_timeout)
+    output=$($SAPCONTROL -nr $InstanceNr -function WaitforStopped $HANA_ACTION_TIMEOUT 1)
     if [ $? -eq 0 ]
     then
       super_ocf_log info "ACT: SAP Instance $SID-$InstanceName stopped: $output"


### PR DESCRIPTION
The resource start and stop timeout is now configurable by increasing the timeout for the action 'start' and/or 'stop'. We will use 95% of this action timeouts to calculate the new resource start and stop timeout for the 'WaitforStarted' and 'WaitforStopped' functions. If the new, calculated timeout value is less than '3600' (now handled as HANA_STD_ACTION_TIMEOUT), it will be set to '3600', so that we do not decrease this timeout by accident (bsc#1182545)