### PR TITLE
man page updates - SAPHanaSR.py.7 and SAPHanaSR_maintenance_examples.7

### DIFF
--- a/man/SAPHanaSR.py.7
+++ b/man/SAPHanaSR.py.7
@@ -1,6 +1,6 @@
-.\" Version: 0.162.3
+.\" Version: 0.155.0
 .\"
-.TH SAPHanaSR.py 7 "26 Oct 2019" "" "SAPHanaSR"
+.TH SAPHanaSR.py 7 "12 Feb 2021" "" "SAPHanaSR"
 .\"
 .SH NAME
 SAPHanaSR.py \- Provider for SAP HANA srHook method srConnectionChanged().
@@ -114,8 +114,11 @@ ha_dr_saphanasr = info
 .PP
 .\"
 .SH REQUIREMENTS 
-1. SAP HANA starting with version 1.0 SPS 11 patch level 112.02.
-Older versions do not provide the srHook method srConnectionChanged().
+1. SAP HANA 2.0 SPS04 or later provides the HA/DR provider hook method
+srConnectionChanegd() with multi-target aware parameters.
+SAP HANA 1.0 does not provide them.
+The multi-target aware parameters are needed for the SAPHanaSR scale-up
+package.
 .PP
 2. The user ${sid}adm needs execution permission as user root for the command crm_attribute. 
 .PP
@@ -155,7 +158,7 @@ F.Herschel, L.Pinne.
 .SH COPYRIGHT
 (c) 2015-2018 SUSE Linux GmbH, Germany.
 .br
-(c) 2019 SUSE LLC
+(c) 2019-2021 SUSE LLC
 .br
 SAPHanaSR.py comes with ABSOLUTELY NO WARRANTY.
 .br

--- a/man/SAPHanaSR_maintenance_examples.7
+++ b/man/SAPHanaSR_maintenance_examples.7
@@ -1,6 +1,6 @@
-.\" Version: 0.154.0
+.\" Version: 0.155.0
 .\"
-.TH SAPHanaSR_maintenance_examples 7 "06 Jun 2018" "" "SAPHanaSR"
+.TH SAPHanaSR_maintenance_examples 7 "12 Feb 2021" "" "SAPHanaSR"
 .\"
 .SH NAME
 SAPHanaSR_maintenance_examples \- maintenance examples for SAPHana and SAPHanaController.
@@ -14,23 +14,23 @@ Please see also the REQUIREMENTS section below.
 .\"
 .SH EXAMPLES
 .PP
-* Initiate an administrative takeover of the HANA primary from one node to the other one. 
-If the cluster should also register the former primary as secondary, AUTOMATED_REGISTER="true" is needed. Before the takeover will be initiated, the status of the Linux cluster and the HANA system replication has to be checked. The takeover should only be initiated as forced migration. After takeover of the primary has been finished, the migration rule has to be deleted. If AUTOMATED_REGISTER="true" is set, finally the former primary will be registred as secondary, once the migration rule has been deleted.
+* Initiate an administrative takeover of the HANA primary from one node to the other one.
+If the cluster should also register the former primary as secondary, AUTOMATED_REGISTER="true" is needed. Before the takeover will be initiated, the status of the Linux cluster and the HANA system replication has to be checked. The takeover should only be initiated as forced migration. After takeover of the primary has been finished, the migration rule has to be deleted. If AUTOMATED_REGISTER="true" is set, finally the former primary will be registred as secondary, once the migration rule has been deleted. The below example works on SLE-HA 12 and 15. Former versions used "migrate" instead of "move" and "unmigrate" instead of "clear".
 .PP
 .RS 2 
 # cs_clusterstate -i
 .br
 # SAPHanaSR-showAttr
 .br
-# crm configure show | grep cli
+# crm configure show | grep cli-
 .br
-# crm resource migrate msl_SAPHana_SLE_HDB10 force
+# crm resource move msl_SAPHana_SLE_HDB10 force
 .br
 # cs_clusterstate -i
 .br
 # SAPHanaSR-showAttr
 .br
-# crm resource unmigrate msl_SAPHana_SLE_HDB10
+# crm resource clear msl_SAPHana_SLE_HDB10
 .br
 # SAPHanaSR-showAttr
 .RE
@@ -50,7 +50,7 @@ If the cluster should also register the former primary as secondary, AUTOMATED_R
 .br
 6. Wait and check for HANA has been promoted to primary by the cluster.
 .br
-7. Remove the migration rule from the IP adress.
+7. Remove the migration rule from the IP address.
 .br
 8. Check if cluster is in status idle.
 .br
@@ -75,7 +75,7 @@ If the cluster should also register the former primary as secondary, AUTOMATED_R
 .br
 6. Set the SAPHanaController master/slave resource back to managed (crm resource manage <resource>)
 .br
-7. Check if everything looks fine (crm_mon -1r, cs_clusterstate -i,
+7. Check if everything looks fine (crm_mon -1r, cs_clusterstate -i, crm configure show | grep cli-,
  SAPHanaSR-showAttr).
 .PP
 .RE
@@ -102,7 +102,7 @@ In case of any problem, please use your favourite SAP support process to open a 
 .SH SEE ALSO
 .br
 \fBocf_suse_SAPHanaTopology\fP(7) , \fBocf_suse_SAPHana\fP(7) , \fBocf_suse_SAPHanaController\fP(7) ,
-\fBSAPHanaSR-monitor\fP(8) , \fBSAPHanaSR-showAttr\fP(8) , \fBSAPHanaSR\fP(7) , \fBSAPHanaSR-ScaleOut\fP(7) ,
+\fBSAPHanaSR-monitor\fP(8) , \fBSAPHanaSR-showAttr\fP(8) , \fBSAPHanaSR\fP(7) , \fBSAPHanaSR-ScaleOut\fP(7) , \fBSAPHanaSR.py\fP(7) ,
 \fBcs_clusterstate\fP(8) ,
 \fBcrm\fP(8) , \fBcrm_simulate\fP(8) , \fBcrm_mon\fP(8) ,
 .br
@@ -119,7 +119,7 @@ F.Herschel, L.Pinne.
 .SH COPYRIGHT
 (c) 2017-2018 SUSE Linux GmbH, Germany.
 .br
-(c) 2019 SUSE LLC
+(c) 2019-2021 SUSE LLC
 .br
 This maintenance examples are coming with ABSOLUTELY NO WARRANTY.
 .br


### PR DESCRIPTION
add correct HANA version needed for the HA/DR provider hook in multi-target environments
fix typos
adjust ''crm resource' options (move/clear instead of migrate/unmigrate)