### PR TITLE
add dedicated logging of HANA_CALL problems - bsc#1182774

### DIFF
--- a/SAPHanaSR.changes_12
+++ b/SAPHanaSR.changes_12
@@ -30,8 +30,8 @@ Tue Mar  9 13:38:06 UTC 2021 - abriel@suse.com
   su command throws the error and for further hints we log the
   stderr output.
   Additional it is possible to get regular log messages for the
-  used commands, their return code and their stderr outout by
-  enabling the 'debug' mode of the ressource agents.
+  used commands, their return code and their stderr output by
+  enabling the 'debug' mode of the resource agents.
   (bsc#1182774)
 
 -------------------------------------------------------------------

--- a/SAPHanaSR.changes_12
+++ b/SAPHanaSR.changes_12
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Thu Mar  4 18:29:15 UTC 2021 - abriel@suse.com
+Tue Mar  9 13:38:06 UTC 2021 - abriel@suse.com
 
 - Version bump to 0.155.0
 - The resource start and stop timeout is now configurable by
@@ -14,6 +14,17 @@ Thu Mar  4 18:29:15 UTC 2021 - abriel@suse.com
   that both sides have an equal promotion scoring after refresh
   which might result in a critical promotion of the secondary.
   (bsc#1174557)
+- update of man page SAPHanaSR.py.7 - correct the supported HANA
+  version.
+  (bsc#1182201)
+- add dedicated logging of HANA_CALL problems. So it will be now
+  possible to identify, if the called hana command or the needed
+  su command throws the error and for further hints we log the
+  stderr output.
+  Additional it is possible to get regular log messages for the
+  used commands, their return code and their stderr outout by
+  enabling the 'debug' mode of the ressource agents.
+  (bsc#1182774)
 
 -------------------------------------------------------------------
 Thu Jul  2 11:27:34 UTC 2020 - abriel@suse.com

--- a/SAPHanaSR.changes_12
+++ b/SAPHanaSR.changes_12
@@ -17,6 +17,14 @@ Tue Mar  9 13:38:06 UTC 2021 - abriel@suse.com
 - update of man page SAPHanaSR.py.7 - correct the supported HANA
   version.
   (bsc#1182201)
+- if the $hdbState command fails to retrieve the current state of
+  the System Replication, the resource agent now uses the
+  system_replication/actual_mode attribute (if available) from the
+  global.ini file as a fallback.
+  This should prevent some confusing and misleading log messages
+  during a takeover and solves the problem of a not working
+  takeover back (after a successful first takeover)
+  (bsc#1181765)
 - add dedicated logging of HANA_CALL problems. So it will be now
   possible to identify, if the called hana command or the needed
   su command throws the error and for further hints we log the

--- a/SAPHanaSR.changes_15
+++ b/SAPHanaSR.changes_15
@@ -30,8 +30,8 @@ Tue Mar  9 13:38:06 UTC 2021 - abriel@suse.com
   su command throws the error and for further hints we log the
   stderr output.
   Additional it is possible to get regular log messages for the
-  used commands, their return code and their stderr outout by
-  enabling the 'debug' mode of the ressource agents.
+  used commands, their return code and their stderr output by
+  enabling the 'debug' mode of the resource agents.
   (bsc#1182774)
 
 -------------------------------------------------------------------

--- a/SAPHanaSR.changes_15
+++ b/SAPHanaSR.changes_15
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Thu Mar  4 18:29:41 UTC 2021 - abriel@suse.com
+Tue Mar  9 13:38:06 UTC 2021 - abriel@suse.com
 
 - Version bump to 0.155.0
 - The resource start and stop timeout is now configurable by
@@ -14,6 +14,17 @@ Thu Mar  4 18:29:41 UTC 2021 - abriel@suse.com
   that both sides have an equal promotion scoring after refresh
   which might result in a critical promotion of the secondary.
   (bsc#1174557)
+- update of man page SAPHanaSR.py.7 - correct the supported HANA
+  version.
+  (bsc#1182201)
+- add dedicated logging of HANA_CALL problems. So it will be now
+  possible to identify, if the called hana command or the needed
+  su command throws the error and for further hints we log the
+  stderr output.
+  Additional it is possible to get regular log messages for the
+  used commands, their return code and their stderr outout by
+  enabling the 'debug' mode of the ressource agents.
+  (bsc#1182774)
 
 -------------------------------------------------------------------
 Thu Jul  2 11:27:34 UTC 2020 - abriel@suse.com

--- a/SAPHanaSR.changes_15
+++ b/SAPHanaSR.changes_15
@@ -17,6 +17,14 @@ Tue Mar  9 13:38:06 UTC 2021 - abriel@suse.com
 - update of man page SAPHanaSR.py.7 - correct the supported HANA
   version.
   (bsc#1182201)
+- if the $hdbState command fails to retrieve the current state of
+  the System Replication, the resource agent now uses the
+  system_replication/actual_mode attribute (if available) from the
+  global.ini file as a fallback.
+  This should prevent some confusing and misleading log messages
+  during a takeover and solves the problem of a not working
+  takeover back (after a successful first takeover)
+  (bsc#1181765)
 - add dedicated logging of HANA_CALL problems. So it will be now
   possible to identify, if the called hana command or the needed
   su command throws the error and for further hints we log the

--- a/man/SAPHanaSR-showAttr.8
+++ b/man/SAPHanaSR-showAttr.8
@@ -100,7 +100,7 @@ Value: [ PROMOTED | DEMOTED | UNDEFINED | WAITING4PRIM | WAITING4NODES | WAITING
 .\" TODO: what kind of attribute?
 This variable is set by the SAPHana resource agent.
 .br
-PROMOTED marks the master state of the instance, wich makes a HANA SR primary.
+PROMOTED marks the master state of the instance, which makes a HANA SR primary.
 .br
 DEMOTED makes a HANA SR secondary.
 The DEMOTED state can be transient, on the way to promoting.

--- a/man/SAPHanaSR.7
+++ b/man/SAPHanaSR.7
@@ -62,7 +62,7 @@ A primary absolutely must never be started, if the cluster does not know
 anything about the other site.
 On initial cluster start, the cluster needs to detect a valid HANA system
 replication setup, including system replication status (SOK) and last primary
-timestamp (LPT). This is neccessary to ensure data integrity.
+timestamp (LPT). This is necessary to ensure data integrity.
 .PP
 The rational behind this is shown in the following scenario:
 .br
@@ -86,7 +86,7 @@ The rational behind this is shown in the following scenario:
     secondary.
 .br
 6.3 It would start the HANA from point of time of step 1.->2. (the crash),
-    so all data changed inbetween would be lost.
+    so all data changed in between would be lost.
 .br
 This is why the Linux cluster needs to enforce a restart inhibit.
 .PP
@@ -166,7 +166,7 @@ cluster tests.
 cluster tests.
 .PP
 \fB*\fR Be patient. For detecting the overall HANA status, the Linux cluster needs
-a certain amount of time, depending on the HANA and the configured intervalls and
+a certain amount of time, depending on the HANA and the configured intervals and
 timeouts.
 .PP
 \fB*\fR Before doing anything, always check for the Linux cluster's idle status,

--- a/man/SAPHanaSR_maintenance_examples.7
+++ b/man/SAPHanaSR_maintenance_examples.7
@@ -46,7 +46,7 @@ If the cluster should also register the former primary as secondary, AUTOMATED_R
 .br
 4. Wait and check for HANA is running.
 .br
-5. In case the cluster does not promote the HANA to primary, instruct the cluster to migrate the IP adress to that node.
+5. In case the cluster does not promote the HANA to primary, instruct the cluster to migrate the IP address to that node.
 .br
 6. Wait and check for HANA has been promoted to primary by the cluster.
 .br

--- a/man/ocf_suse_SAPHana.7
+++ b/man/ocf_suse_SAPHana.7
@@ -374,11 +374,11 @@ This might  be  necessary in case the cluster could not detect the status of bot
 .br
 4. Wait and check for HANA is running.
 .br
-5. In case the cluster does not promote the HANA to primary, instruct the cluster to migrate the IP adress to that node.
+5. In case the cluster does not promote the HANA to primary, instruct the cluster to migrate the IP address to that node.
 .br
 6. Wait and check for HANA gets promoted to primary by the cluster.
 .br
-7. Remove the migration rule from the IP adress.
+7. Remove the migration rule from the IP address.
 .br
 8. You are done, for now.
 .br

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -1155,7 +1155,7 @@ function analyze_hana_sync_statusSRS()
           lpa_set_lpt 10 "$remoteNode"
        fi
     elif [ $srRc -le 11 ]; then # 11 and 10
-       # if systemReplicationStatus is ERROR and landscapeHostConfiguration is down than do NOT set SFAIL
+       # if systemReplicationStatus is ERROR and landscapeHostConfiguration is down then do NOT set SFAIL
        get_hana_landscape_status; lss=$?
        if [ $lss -lt 2 ]; then
           # keep everithing like it was
@@ -1354,7 +1354,7 @@ function saphana_start() {
     check_sapstartsrv
     rc=$?
     #
-    # DONE: ASK: PRIO5: For SCALE-OUT - do we need to use an other call like StartSystem? Or better to use the HDB command?
+    # DONE: ASK: PRIO5: For SCALE-OUT - do we need to use another call like StartSystem? Or better to use the HDB command?
     #
     if [ $rc -eq $OCF_SUCCESS ]; then
         ATTR=(${ATTR_NAME_HANA_SRHOOK[@]}); ATTR[0]="${ATTR[0]}_$sr_name"
@@ -1369,7 +1369,7 @@ function saphana_start() {
     fi
     if [ $rc -eq 0 ]
     then
-        # DONE: PRIO9: something more dynamic than 3600 seconds in WaitforStarted
+        # DONE: PRIO9: something more dynamic ehan 3600 seconds in WaitforStarted
         HANA_ACTION_TIMEOUT=$(get_action_timeout)
         output=$($SAPCONTROL -nr $InstanceNr -function WaitforStarted $HANA_ACTION_TIMEOUT 1)
         if [ $? -eq 0 ]
@@ -1467,7 +1467,7 @@ function saphana_start_primary()
     local lpa_dec=4
     local lpa_advice=""
     #
-    # we will be a master (PRIMARY) so checking, if the is an OTHER master
+    # we will be a master (PRIMARY) so checking, if the is anOTHER master
     #
     super_ocf_log debug "DBG: saphana_primary - check_for_primary reports HANA_STATE_PRIMARY"
     #
@@ -1513,7 +1513,7 @@ function saphana_start_primary()
         4) # LPA says something is completely wrong - FAIL resource # TODO: PRIO1: RC3 for waiting remote side to report lss
             lpa_advice="fail"
             ;;
-        *) # LPA failed with an unkonown status - FAIL resource
+        *) # LPA failed with an unknown status - FAIL resource
             lpa_advice="fail"
             ;;
     esac
@@ -1531,14 +1531,14 @@ function saphana_start_primary()
     case "$lpa_advice" in
         start )  # process a normal START
             case "$lss" in
-                2 | 3 | 4 ) # as landcape says we are up - just set the scores and return code
-                    super_ocf_log info "LPA: landcape: UP, LPA: start ==> keep running"
+                2 | 3 | 4 ) # as landscape says we are up - just set the scores and return code
+                    super_ocf_log info "LPA: landscape: UP, LPA: start ==> keep running"
                     LPTloc=$(date '+%s')
                     lpa_set_lpt $LPTloc $NODENAME
                     rc=$OCF_SUCCESS
                     ;;
-                1 ) # landcape says we are down, lets start and adjust scores and return code
-                    super_ocf_log info "LPA: landcape: DOWN, LPA: start ==> start instance"
+                1 ) # landscape says we are down, lets start and adjust scores and return code
+                    super_ocf_log info "LPA: landscape: DOWN, LPA: start ==> start instance"
                     saphana_start
                     rc=$?
                     LPTloc=$(date '+%s')
@@ -1553,7 +1553,7 @@ function saphana_start_primary()
             ;;
         register ) # process a REGISTER
             case "$lss" in
-                2 | 3 | 4 ) # upps we are up - but shoudn't? - we could not register with started HDB
+                2 | 3 | 4 ) # upps we are up - but shouldn't? - we could not register with started HDB
                     # DONE: PRIO3: check if this reaction is correct - tell cluster about failed start
                     super_ocf_log info "LPA: landscape: UP, LPA: register ==> take down"
                     set_crm_master -inf
@@ -1562,7 +1562,7 @@ function saphana_start_primary()
                 1 ) # lets try to register
                     # DONE: PRIO2: Like Action in start_secondary
                     super_ocf_log info "LPA: landscape: DOWN, LPA: register ==> try to register"
-                    super_ocf_log info "DEC: AN OTHER HANA IS AVAILABLE ==> LETS REGISTER"
+                    super_ocf_log info "DEC: ANOTHER HANA IS AVAILABLE ==> LETS REGISTER"
                     set_crm_master  0
                     if wait_for_primary_master 1; then
                         register_hana_secondary
@@ -1601,8 +1601,8 @@ function saphana_start_primary()
                 1 ) # we are down, so we should wait --> followup in next monitor
                     # DONE: PRIO3: Check, if WAITING is correct here
                     if ocf_is_true "$AUTOMATED_REGISTER" ; then
-                        super_ocf_log info "LPA: landcape: DOWN, LPA: wait ==> keep waiting"
-                        super_ocf_log info "RA: landcape: DOWN, LPA: wait ==> keep waiting"
+                        super_ocf_log info "LPA: landscape: DOWN, LPA: wait ==> keep waiting"
+                        super_ocf_log info "RA: landscape: DOWN, LPA: wait ==> keep waiting"
                         set_hana_attribute ${NODENAME} "WAITING4LPA" ${ATTR_NAME_HANA_CLONE_STATE[@]}
                         set_crm_master -9000
                         rc=$OCF_SUCCESS
@@ -1714,9 +1714,9 @@ function saphana_start_secondary()
     #
     #
     # we would be secondary
-    # we first need to check, if there are Master Nodes, because the Scecondary only starts
-    # successfuly, if the Primary is available. Thatfore we mark the Secondary as "WAITING"
-    # DONE: PRIO3: wait_for_primary_master 10 is just a test value: 10 loops x10 seconds than go to WAITING
+    # we first need to check, if there are Master Nodes, because the Secondary only starts
+    # successfully, if the Primary is available. Therefor we mark the Secondary as "WAITING"
+    # DONE: PRIO3: wait_for_primary_master 10 is just a test value: 10 loops x10 seconds, then go to WAITING
     # DONE: PRIO3: rename 'wait_for_primary_master' to match better the use case ("wait_some_time")
     #
     super_ocf_log debug "DBG: wait for promoted side"
@@ -1726,9 +1726,9 @@ function saphana_start_secondary()
        saphana_start; rc=$?
        if [ $rc -ne $OCF_SUCCESS ]; then
            if ! wait_for_primary_master 1; then
-               # It seams the stating secondary could not start because of stopping primary
+               # It seems the stating secondary could not start because of stopping primary
                #    so this is a WAITING situation
-               super_ocf_log info "ACT: PRIMARY seams to be down now ==> WAITING"
+               super_ocf_log info "ACT: PRIMARY seems to be down now ==> WAITING"
                set_hana_attribute ${NODENAME} "WAITING4PRIM" ${ATTR_NAME_HANA_CLONE_STATE[@]}
                set_crm_master -INFINITY
                rc=$OCF_SUCCESS
@@ -2590,7 +2590,7 @@ function saphana_promote_clone() {
         esac
      else
         #
-        # neither PRIMARY nor SECONDARY - This clone instance seams to be broken!!
+        # neither PRIMARY nor SECONDARY - This clone instance seems to be broken!!
         # bsc#1027098 - do not stop SAP HANA if "only" HANA state is not correct
         # Let next monitor find, if that HANA instance is available or not
         rc=$OCF_SUCCESS;
@@ -2723,7 +2723,7 @@ case "$ACTION" in
     reload)
         ra_rc=$OCF_SUCCESS
         ;;
-    *)  # seams to be a unknown request
+    *)  # seems to be an unknown request
         saphana_methods
         ra_rc=$OCF_ERR_UNIMPLEMENTED
         ;;

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -1114,7 +1114,7 @@ function check_for_primary() {
 # systemReplicationStatus.py return-codes:
 #    NoHSR        = 10
 #    Error        = 11
-#    Unkown       = 12
+#    Unknown      = 12
 #    Initializing = 13
 #    Syncing      = 14
 #    Active       = 15
@@ -2708,7 +2708,7 @@ fi
 super_ocf_log info "RA ==== begin action $ACTION$CLACT ($SAPHanaVersion) ===="
 ra_rc=$OCF_ERR_UNIMPLEMENTED
 case "$ACTION" in
-    start|stop|monitor|promote|demote) # Standard controling actions
+    start|stop|monitor|promote|demote) # Standard controlling actions
         saphana_$ACTION$CLACT
         ra_rc=$?
         ;;

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -670,7 +670,26 @@ function HANA_CALL()
                   output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
                   ;;
         *       )
-                  output=$(timeout --foreground -s 9 $timeOut $pre_cmd "$pre_script; timeout -s 9 $timeOut /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
+                  errExt=$(date '+%s')
+                  su_err_log=/tmp/HANA_CALL_SU_RA_${errExt}
+                  cmd_out_log=/tmp/HANA_CALL_CMD_RA_OUT_${errExt}
+                  cmd_err_log=/tmp/HANA_CALL_CMD_RA_${errExt}
+
+                  output=$(timeout --foreground -s 9 "$timeOut" "$pre_cmd" "($pre_script; timeout -s 9 $timeOut /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd > $cmd_out_log) >& $cmd_err_log" 2>"$su_err_log"); rc=$?
+
+                  output=$(if [ -f "$cmd_out_log" ]; then cat "$cmd_out_log"; rm -f "$cmd_out_log"; fi)
+                  suErr=$(if [ -f "$su_err_log" ]; then cat "$su_err_log"; rm -f "$su_err_log"; else echo "NA"; fi)
+                  cmdErr=$(if [ -f "$cmd_err_log" ]; then cat "$cmd_err_log"; rm -f "$cmd_err_log"; else echo "NA"; fi)
+                  super_ocf_log debug "DBG: RA ==== action HANA_CALL (cmd is '$cmd', rc is '$rc', stderr from su is '$suErr', stderr from cmd is '$cmdErr') ===="
+                  # on rc=1 - retry to improve the behavior in AD environments
+                  if [ $rc -eq 1 ]; then
+                      super_ocf_log warn "HANA_CALL stderr from command '$pre_cmd' is '$suErr', stderr from command '$cmd' is '$cmdErr'"
+                      if [ "$cmdErr" == "NA" ]; then
+                          # seems something was going wrong with the 'pre_cmd' (su)
+                          super_ocf_log warn "DEC: HANA_CALL returned '1' for command '$pre_cmd'. Retry once."
+                          output=$(timeout --foreground -s 9 "$timeOut" "$pre_cmd" "$pre_script; timeout -s 9 $timeOut /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
+                      fi
+                  fi
                   #
                   # on timeout ...
                   #

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -566,7 +566,7 @@ function sht_init() {
                 super_ocf_log info "ACT: hdbnsutil not answering - using global.ini as fallback - srmode=$srmode"
                 ;;
             hU | * ) # call hdbnsUtil (hU) ( also for unknown chkMethod )
-                # DONE: PRIO1: Begginning from SAP HANA rev 112.03 -sr_state is not longer supported
+                # DONE: PRIO1: Beginning from SAP HANA rev 112.03 -sr_state is not longer supported
                 hdbANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "$hdbState --sapcontrol=1" 2>/dev/null)
                 srmode=$(echo "$hdbANSWER" | awk -F= '$1=="mode" {print $2}')
                 ;;
@@ -1113,7 +1113,7 @@ case "$ACTION" in
     reload )
         ra_rc="$OCF_SUCCESS"
         ;;
-    *)  # seams to be a unknown request
+    *)  # seems to be an unknown request
         sht_methods
         ra_rc=$OCF_ERR_UNIMPLEMENTED
         ;;

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -27,7 +27,7 @@
 #
 #######################################################################
 # DONE PRIO 1: AFTER(!) SAP HANA SPS12 is available we could use hdbnsutil --sr_stateConfiguration
-SAPHanaTopologyVersion="0.154.0"
+SAPHanaTopologyVersion="0.155.0"
 #
 # Initialization:
 timeB=$(date '+%s')
@@ -429,7 +429,26 @@ function HANA_CALL()
                   output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
                   ;;
         *       )
-                  output=$(timeout $timeOut $pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
+                  errExt=$(date '+%s')
+                  su_err_log=/tmp/HANA_CALL_SU_TOP_${errExt}
+                  cmd_out_log=/tmp/HANA_CALL_CMD_TOP_OUT_${errExt}
+                  cmd_err_log=/tmp/HANA_CALL_CMD_TOP_${errExt}
+
+                  output=$(timeout "$timeOut" "$pre_cmd" "($pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd > $cmd_out_log) >& $cmd_err_log" 2>"$su_err_log"); rc=$?
+
+                  output=$(if [ -f "$cmd_out_log" ]; then cat "$cmd_out_log"; rm -f "$cmd_out_log"; fi)
+                  suErr=$(if [ -f "$su_err_log" ]; then cat "$su_err_log"; rm -f "$su_err_log"; else echo "NA"; fi)
+                  cmdErr=$(if [ -f "$cmd_err_log" ]; then cat "$cmd_err_log"; rm -f "$cmd_err_log"; else echo "NA"; fi)
+                  super_ocf_log debug "DBG: RA ==== action HANA_CALL (cmd is '$cmd', rc is '$rc', stderr from su is '$suErr', stderr from cmd is '$cmdErr') ===="
+                  # on rc=1 - retry to improve the behavior in AD environments
+                  if [ $rc -eq 1 ]; then
+                      super_ocf_log warn "HANA_CALL stderr from command '$pre_cmd' is '$suErr', stderr from command '$cmd' is '$cmdErr'"
+                      if [ "$cmdErr" == "NA" ]; then
+                          # seems something was going wrong with the 'pre_cmd' (su)
+                          super_ocf_log warn "DEC: HANA_CALL returned '1' for command '$pre_cmd'. Retry once."
+                          output=$(timeout "$timeOut" "$pre_cmd" "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
+                      fi
+                  fi
                   #
                   # on timeout ...
                   #

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -560,9 +560,13 @@ function sht_init() {
         case "$chkMethod" in
             gP ) # call getParameter (gP)
                 local gpKeys=""
-                gpKeys=$(echo --key=global.ini/system_replication/{mode,site_name,site_id})
+                gpKeys=$(echo --key=global.ini/system_replication/{actual_mode,mode,site_name,site_id})
                 hdbANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "HDBSettings.sh getParameter.py $gpKeys --sapcontrol=1" 2>&1 | awk -F/ 'BEGIN {out=0} /^SAPCONTROL-OK: <begin>/ { out=1 } /^SAPCONTROL-OK: <end>/ { out=0 } /=/ {if (out==1) {print $3} }')
-                srmode=$(echo "$hdbANSWER" | awk -F= '$1=="mode" {print $2}')
+                srmode=$(echo "$hdbANSWER" | awk -F= '$1=="actual_mode" {print $2}')
+                # if 'actual_mode' is not available, fallback to 'mode'
+                if [ -z "$srmode" ]; then
+                    srmode=$(echo "$hdbANSWER" | awk -F= '$1=="mode" {print $2}')
+                fi
                 super_ocf_log info "ACT: hdbnsutil not answering - using global.ini as fallback - srmode=$srmode"
                 ;;
             hU | * ) # call hdbnsUtil (hU) ( also for unknown chkMethod )
@@ -586,7 +590,13 @@ function sht_init() {
     siteID=$(echo "$hdbANSWER" | awk -F= '/site.id/ {print $2}')       # allow 'site_id' AND 'site id'
     siteNAME=$(echo "$hdbANSWER" | awk -F= '/site.name/ {print $2}')
     site=$siteNAME
-    srmode=$(echo "$hdbANSWER" | awk -F= '$1=="mode" {print $2}')
+    if [ -z "$srmode" ]; then
+        srmode=$(echo "$hdbANSWER" | awk -F= '$1=="actual_mode" {print $2}')
+        # if 'actual_mode' is not available, fallback to 'mode'
+        if [ -z "$srmode" ]; then
+            srmode=$(echo "$hdbANSWER" | awk -F= '$1=="mode" {print $2}')
+        fi
+    fi
     #
     # for rev >= 111 we use the new mapping query
     #

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -958,7 +958,7 @@ function sht_monitor_clone() {
     setRole=true
     if version "$hdbver" ">=" "1.00.100"; then
         hanaANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "landscapeHostConfiguration.py --sapcontrol=1" 2>/dev/null); hanalrc="$?"
-        # retry command, if a timeout occured
+        # retry command, if a timeout occurred
         if [ "$hanalrc" -ge 124 ]; then
             super_ocf_log warn "HANA_CALL timed out after $HANA_CALL_TIMEOUT seconds running command 'landscapeHostConfiguration.py --sapcontrol=1'. Retrying..."
             hanaANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "landscapeHostConfiguration.py --sapcontrol=1" 2>/dev/null); hanalrc="$?"
@@ -978,10 +978,10 @@ function sht_monitor_clone() {
                      END { printf "%s:%s:%s:%s\n", f1, f2, f3,f4 }')
     else
         #
-        # old code for backward compatability
+        # old code for backward compatibility
         #
         hanaANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "landscapeHostConfiguration.py" 2>/dev/null); hanalrc="$?"
-        # retry command, if a timeout occured
+        # retry command, if a timeout occurred
         if [ "$hanalrc" -ge 124 ]; then
             super_ocf_log warn "HANA_CALL timed out after $HANA_CALL_TIMEOUT seconds running command 'landscapeHostConfiguration.py'. Retrying..."
             hanaANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "landscapeHostConfiguration.py" 2>/dev/null); hanalrc="$?"
@@ -1112,7 +1112,7 @@ fi
 super_ocf_log info "RA ==== begin action $ACTION$CLACT ($SAPHanaTopologyVersion) ===="
 ra_rc=$OCF_ERR_UNIMPLEMENTED
 case "$ACTION" in
-    start|stop|monitor) # Standard controling actions
+    start|stop|monitor) # Standard controlling actions
         sht_$ACTION$CLACT
         ra_rc=$?
         ;;


### PR DESCRIPTION
It will be now possible to identify, if the called hana command or the needed su command throws the error and for further hints we log the stderr output.
Additional it is possible to get regular log messages for the used commands, their return code and their stderr output by enabling the 'debug' mode of the resource agents.
(bsc#1182774)

And fixed some typos.