### PR TITLE
The return value of 'systemctl list-unit-files <service>' is not reli…

### DIFF
--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -956,7 +956,8 @@ function chk4systemdsupport() {
     if [ -x "$SYSTEMCTL" ]; then
         if [ -f /etc/systemd/system/"$systemd_unit_name" ]; then
             rc=0
-        elif $SYSTEMCTL list-unit-files "$systemd_unit_name" >/dev/null 2>&1; then
+        elif $SYSTEMCTL list-unit-files | \
+            awk '$1 == service { found=1 } END { if (! found) {exit 1}}' service="${systemd_unit_name}.service"; then
             rc=0
         else
             rc=1

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -674,7 +674,8 @@ function chk4systemdsupport() {
     if [ -x "$SYSTEMCTL" ]; then
         if [ -f /etc/systemd/system/"$systemd_unit_name" ]; then
             rc=0
-        elif $SYSTEMCTL list-unit-files "$systemd_unit_name" >/dev/null 2>&1; then
+        elif $SYSTEMCTL list-unit-files | \
+            awk '$1 == service { found=1 } END { if (! found) {exit 1}}' service="${systemd_unit_name}.service"; then
             rc=0
         else
             rc=1


### PR DESCRIPTION
…able on all SLE15 codestreams, so it is not usable for our resource agents. We need to go back to parsing the command output instead and hoping, that the output format will not change in the future, because that will breake the solution again as well.