### PR TITLE
SAPHana*: follow OCF standard for version and OCF version in metadata

### DIFF
--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -160,8 +160,8 @@ function saphana_meta_data() {
     cat <<END
 <?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
-<resource-agent name="SAPHana">
-<version>$SAPHanaVersion</version>
+<resource-agent name="SAPHana" version="$SAPHanaVersion">
+<version>1.0</version>
 
 <shortdesc lang="en">Manages two SAP HANA database systems in system replication (SR).</shortdesc>
 <longdesc lang="en">

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -134,8 +134,8 @@ function sht_meta_data() {
 	cat <<END
 <?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
-<resource-agent name="SAPHanaTopology">
-    <version>$SAPHanaTopologyVersion</version>
+<resource-agent name="SAPHanaTopology" version="$SAPHanaTopologyVersion">
+    <version>1.0</version>
     <shortdesc lang="en">Analyzes SAP HANA System Replication Topology.</shortdesc>
     <longdesc lang="en">This RA analyzes the SAP HANA topology and "sends" all findings via the node status attributes to
         all nodes in the cluster. These attributes are taken by the SAPHana RA to control the SAP Hana Databases.


### PR DESCRIPTION
Latest version of pcs will fail when these arent correct.

For reference from the main resource-agents repo:
https://github.com/ClusterLabs/resource-agents/pull/1700