### PR TITLE
fix table tiltes in SAPHanaSR-showAttr when short sites are used

### DIFF
--- a/test/SAPHanaSRTools.pm
+++ b/test/SAPHanaSRTools.pm
@@ -696,7 +696,7 @@ sub host_attr2string
         $format="script"
     }
     if ( $format eq "tables" ) {
-	    $hclen=$$refN{_hosts}->{_length};
+        $hclen=max($$refN{_hosts}->{_length}, length($title));
 	    $line_len=$hclen+1;
 	    $string.=sprintf "%-$hclen.${hclen}s ", "$title";
 	    #


### PR DESCRIPTION
Now SAPHanaSR-showAttr could print site tables like the following, if site names are shorter than "Sites":

```
Sites srHook 
-------------
ROT   SOK    
WDF   PRIM
```