### PR TITLE
Improve log messages about saphostagent status

### DIFF
--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -773,7 +773,7 @@ function check_saphostagent()
     if chk4systemdsupport; then
         # use systemd to control saphostagent
         if $SYSTEMCTL is-active --quiet "$systemd_unit_name"; then
-            super_ocf_log warn "ACT: systemd service $systemd_unit_name is active"
+            super_ocf_log info "ACT: systemd service $systemd_unit_name is active"
             rc=0
         else
             super_ocf_log info "ACT: systemd service $systemd_unit_name is not active"


### PR DESCRIPTION
SAPHanaTopology: while checking saphostagent it only an info and not a warning, if saphostagent is running