### PR TITLE
remove info about SAP systemd support from SLE12 changelog

### DIFF
--- a/SAPHanaSR.changes_12
+++ b/SAPHanaSR.changes_12
@@ -2,13 +2,6 @@
 Tue Nov 23 18:21:36 UTC 2021 - abriel@suse.com
 
 - Version bump to 0.155.0
-- Add systemd support for the resource agent to interact with the
-  new SAP unit files for sapstartsrv.
-  As the new version of the SAP Startup Framework will use systemd
-  unit files to control the sapstartsrv process instead of the
-  previous used SysV init script, we need to adapt the handling of
-  sapstartsrv inside the resource agents to support both ways.
-  (bsc#1189530, bsc#1189531)
 - The resource start and stop timeout is now configurable by
   increasing the timeout for the action 'start' and/or 'stop'.
   We will use 95% of this action timeouts to calculate the new


### PR DESCRIPTION
As the SAP Startup framework using systemd is not supported on SLE12 (from SAP side) remove the information from the change log to not confuse the customers.