### PR TITLE
Fix HANA_CALL function for MCOS environments (bsc#1198780)

### DIFF
--- a/SAPHanaSR.changes_12
+++ b/SAPHanaSR.changes_12
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Mon May 16 07:37:08 UTC 2022 - abriel@suse.com
+
+- Version bump to 0.155.1
+- fix HANA_CALL function to support MCOS environments again
+  (bsc#1198780)
+- fix SAPHanaSR-replay-archive to handle hb_report archives again
+  (bsc#1198897)
+
+-------------------------------------------------------------------
 Tue Nov 23 18:21:36 UTC 2021 - abriel@suse.com
 
 - Version bump to 0.155.0

--- a/SAPHanaSR.changes_15
+++ b/SAPHanaSR.changes_15
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Mon May 16 07:37:08 UTC 2022 - abriel@suse.com
+
+- Version bump to 0.155.1
+- fix HANA_CALL function to support MCOS environments again
+  (bsc#1198780)
+- fix SAPHanaSR-replay-archive to handle hb_report archives again
+  (bsc#1198897)
+
+-------------------------------------------------------------------
 Tue Nov 23 18:34:36 UTC 2021 - abriel@suse.com
 
 - Version bump to 0.155.0

--- a/SAPHanaSR.spec
+++ b/SAPHanaSR.spec
@@ -21,7 +21,7 @@ License:        GPL-2.0
 Group:          Productivity/Clustering/HA
 AutoReqProv:    on
 Summary:        Resource agents to control the HANA database in system replication setup
-Version:        0.155.0
+Version:        0.155.1
 Release:        0
 Url:            http://scn.sap.com/community/hana-in-memory/blog/2014/04/04/fail-safe-operation-of-sap-hana-suse-extends-its-high-availability-solution
 

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -39,7 +39,7 @@
 #     systemReplicationStatus.py (>= SPS090)
 #
 #######################################################################
-SAPHanaVersion="0.155.0"
+SAPHanaVersion="0.155.1"
 #
 # Initialization:
 timeB=$(date '+%s')

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -661,7 +661,7 @@ function HANA_CALL()
                   output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
                   ;;
         *       )
-                  errExt=$(date '+%s')
+                  errExt=$(date '+%s')_${sid}adm
                   su_err_log=/tmp/HANA_CALL_SU_RA_${errExt}
                   cmd_out_log=/tmp/HANA_CALL_CMD_RA_OUT_${errExt}
                   cmd_err_log=/tmp/HANA_CALL_CMD_RA_${errExt}

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -661,7 +661,7 @@ function HANA_CALL()
                   output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
                   ;;
         *       )
-                  errExt=$(date '+%s')_${sid}adm
+                  errExt=$(date '+%s%N')_${sid}adm
                   su_err_log=/tmp/HANA_CALL_SU_RA_${errExt}
                   cmd_out_log=/tmp/HANA_CALL_CMD_RA_OUT_${errExt}
                   cmd_err_log=/tmp/HANA_CALL_CMD_RA_${errExt}

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -420,7 +420,7 @@ function HANA_CALL()
                   output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
                   ;;
         *       )
-                  errExt=$(date '+%s')
+                  errExt=$(date '+%s')_${sid}adm
                   su_err_log=/tmp/HANA_CALL_SU_TOP_${errExt}
                   cmd_out_log=/tmp/HANA_CALL_CMD_TOP_OUT_${errExt}
                   cmd_err_log=/tmp/HANA_CALL_CMD_TOP_${errExt}

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -27,7 +27,7 @@
 #
 #######################################################################
 # DONE PRIO 1: AFTER(!) SAP HANA SPS12 is available we could use hdbnsutil --sr_stateConfiguration
-SAPHanaTopologyVersion="0.155.0"
+SAPHanaTopologyVersion="0.155.1"
 #
 # Initialization:
 timeB=$(date '+%s')

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -420,7 +420,7 @@ function HANA_CALL()
                   output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
                   ;;
         *       )
-                  errExt=$(date '+%s')_${sid}adm
+                  errExt=$(date '+%s%N')_${sid}adm
                   su_err_log=/tmp/HANA_CALL_SU_TOP_${errExt}
                   cmd_out_log=/tmp/HANA_CALL_CMD_TOP_OUT_${errExt}
                   cmd_err_log=/tmp/HANA_CALL_CMD_TOP_${errExt}


### PR DESCRIPTION
fix HANA_CALL function to support MCOS environments again 
use additional 'nanoseconds' and the 'sidadm' user for creating the temporary filename to be unique between the different HANA systems running on the same host. (bsc#1198780)