### PR TITLE
SAPHanaSR-hookHelper improvement

### DIFF
--- a/test/SAPHanaSR-hookHelper
+++ b/test/SAPHanaSR-hookHelper
@@ -3,7 +3,7 @@
 # Helper script for HA/DR hooks
 # currently the only use case is 'checkTakeover' for the TakeOver Hook
 
-# For now we only check the maintenance mode of the multi-state ressource (as descibed in the official supported maintenance procedure described in man page SAPHanaSR_maitenance_examples(7) - EXAMPLES: * Perform an SAP HANA take-over by using SAP tools. 
+# For now we only check the maintenance mode of the multi-state ressource (as descibed in the official supported maintenance procedure described in man page SAPHanaSR_maitenance_examples(7) - EXAMPLES: * Perform an SAP HANA take-over by using SAP tools.
 
 # Definition of the exit codes returned to the hook scripts:
 # 0 - OK
@@ -89,6 +89,13 @@ else
         --sid=?*)
             SID=${1#*=}
             ;;
+        --case=?*)
+            USECASE=${1#*=}
+          ;;
+        --sid)
+          SID="$2"
+          shift
+          ;;
         --case)
             USECASE="$2"
             shift

--- a/test/SAPHanaSR-hookHelper
+++ b/test/SAPHanaSR-hookHelper
@@ -151,7 +151,8 @@ case "$USECASE" in
 #    chk_next_case; rc=$?
 #    ;;
 *)
-    wr_info -eh "Unsupported use case. Exiting...."
+    echo "ERROR: Unsupported use case '$USECASE'. Exiting...."
+    usage
     rc=1
     ;;
 esac


### PR DESCRIPTION
1. allow flexible option syntax (--option value AND --option=value)
2. removed wr_info call (was defined in scale-out toolset)