### PR TITLE
Fix: Missing SRHOOK2 line if SRHOOK1 is set

### DIFF
--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -708,8 +708,8 @@ function get_SRHOOK()
     super_ocf_log info "RA: SRHOOK1=$my_sync"
     if [ -z "$my_sync" -o "$my_sync" = "SWAIT" ]; then
         my_sync=$(get_hana_attribute "$get_sr_host" "${ATTR_NAME_HANA_SYNC_STATUS[@]}")
-    super_ocf_log info "RA: SRHOOK2=$my_sync"
     fi
+    super_ocf_log info "RA: SRHOOK2=$my_sync"
     if [ -z "$my_sync" ]; then   # be pesimistic, if we could not determine the SR attribute
         my_sync="SFAIL"
     fi


### PR DESCRIPTION
The log line and the fi line were swapped for SRHOOK2. The result is
that if SRHOOK1 is set, then SRHOOK3 gets printed but SRHOOK2 does not.
This is confusing.

Signed-off-by: Reid Wahl <nrwahl@protonmail.com>