### PR TITLE
bsc#1198127

### DIFF
--- a/SAPHanaSR.spec
+++ b/SAPHanaSR.spec
@@ -40,6 +40,7 @@ Requires:       perl
 Requires:       crmsh
 Requires:       crmsh-scripts >= 2.2.0
 Requires:       python3
+Requires:       /usr/bin/xmllint
 BuildRequires:  resource-agents
 BuildRequires:  crmsh
 BuildRequires:  crmsh-scripts

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -2841,9 +2841,15 @@ function saphana_promote_clone() {
 #
 function saphana_demote_clone() {
     super_ocf_log info "FLOW $FUNCNAME ($*)"
-    local rc=$OCF_ERR_GENERIC;
+    local rc=$OCF_ERR_GENERIC
     set_hana_attribute "${NODENAME}" "DEMOTED" "${ATTR_NAME_HANA_CLONE_STATE[@]}"
-    rc=$OCF_SUCCESS;
+    # bsc#1198127: let it fail, to get the resource stopped.
+    my_role=$(get_hana_attribute "${NODENAME}" "${ATTR_NAME_HANA_ROLES[@]}")
+    if [ "$my_role" == "1:P:-:-:-:-*" ]; then
+        rc=$OCF_ERR_GENERIC
+    else
+        rc=$OCF_SUCCESS
+    fi
     super_ocf_log info "ACT: Demoted $SID-$InstanceName."
     super_ocf_log info "FLOW $FUNCNAME rc=$rc"
     return $rc

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -961,7 +961,7 @@ function sht_stop_clone() {
                      $1 == "indexServerConfigRole"   {f3=$2}
                      $1 == "indexServerActualRole"   {f4=$2}
                      END { printf "%s:%s:%s:%s\n", f1, f2, f3,f4 }')
-        set_hana_attribute ${NODENAME} "$hanalrc:$hanaPrim:$hanarole" ${ATTR_NAME_HANA_ROLES[@]}
+        set_hana_attribute "${NODENAME}" "$hanalrc:$hanaPrim:$hanarole" ${ATTR_NAME_HANA_ROLES[@]}
     fi
     sht_stop; rc=$? # till now it returns everytime $OCF_SUCCESS
     if [ "$tout" -eq 1 ]; then

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -935,6 +935,7 @@ function sht_start_clone() {
 function sht_stop_clone() {
     super_ocf_log info "FLOW $FUNCNAME ($*)"
     local rc=0
+    local tout=0
     check_for_primary; primary_status=$?
     if [ $primary_status -eq $HANA_STATE_PRIMARY ]; then
         hanaPrim="P"
@@ -945,8 +946,28 @@ function sht_stop_clone() {
     else
         hanaPrim="-"
     fi
-    set_hana_attribute "${NODENAME}" "1:$hanaPrim:-:-:-:-" ${ATTR_NAME_HANA_ROLES[@]}
-    sht_stop; rc=$?
+    # bsc#1198127
+    hanaANSWER=$(HANA_CALL --timeout 300 --cmd "landscapeHostConfiguration.py --sapcontrol=1" 2>/dev/null); hanalrc="$?"
+    if [ "$hanalrc" -ge 124 ]; then
+        # timeout of HANA_CALL, set role to '1:P:-:-:-:-' to get the
+        # saphana_demote_clone to fail and stop the resource
+        set_hana_attribute "${NODENAME}" "1:$hanaPrim:-:-:-:-" ${ATTR_NAME_HANA_ROLES[@]}
+        # and exit with 1 to let the stop fail
+        tout=1
+    else
+        hanarole=$(echo "$hanaANSWER" | tr -d ' ' | \
+            awk -F= '$1 == "nameServerConfigRole"    {f1=$2}
+                     $1 == "nameServerActualRole"    {f2=$2}
+                     $1 == "indexServerConfigRole"   {f3=$2}
+                     $1 == "indexServerActualRole"   {f4=$2}
+                     END { printf "%s:%s:%s:%s\n", f1, f2, f3,f4 }')
+        set_hana_attribute ${NODENAME} "$hanalrc:$hanaPrim:$hanarole" ${ATTR_NAME_HANA_ROLES[@]}
+    fi
+    sht_stop; rc=$? # till now it returns everytime $OCF_SUCCESS
+    if [ "$tout" -eq 1 ]; then
+        # timeout of landscapeHostConfiguration.py - let stop fail
+	rc=$OCF_ERR_GENERIC
+    fi
     return $rc
 }
 


### PR DESCRIPTION
change function saphana_demote_clone - if the role is '1:P' let the function fail with rc=1, to get the resource stopped
change function sht_stop_clone - call landscapeHostConfiguration.py and set the roles as they are reported. If the command timed out, return 1 to get the node fenced.

This is the change we discussed some time ago. First tests in a really small cluster worked. The idea behind the PR against 'TEAM-4711' is to have a broader test base during your currently running 'fast dying indexserver' tests.
If that's not possible, simply decline the PR.