### PR TITLE
super_ocf_log - get rid of external grep call; harmonize SAPHana/SAPHanaTopology

### DIFF
--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -78,8 +78,8 @@ function super_ocf_log() {
     local message="$2"
     local skip=1
     local mtype=""
-    local search=0
     local shf="${SAPHanaFilter:-all}"
+    #ocf_log "info" "super_ocf_log: f:$shf l:$level m:$message"
     # message levels: (dbg)|info|warn|err|error
     # message types:  (ACT|RA|FLOW|DBG|LPA|DEC|DBG2...
     case "$level" in
@@ -95,12 +95,7 @@ function super_ocf_log() {
             * ) mtype=${message%% *}
                 mtype=${mtype%:}
                 mtype=${mtype#fh}
-                echo "$shf"|  grep -iq ${mtype}; search=$?
-                if [ $search -eq 0 ]; then
-                     skip=0
-                else
-                    skip=1
-                fi
+                [[ ${shf} == *${mtype}* ]] && skip=0 || skip=1
             ;;
         esac
         ;;
@@ -2873,8 +2868,7 @@ SAPSTARTSRV=""
 SAPCONTROL=""
 DIR_PROFILE=""
 SAPSTARTPROFILE=""
-SAPHanaFilter="ra-act-dec-lpa"
-
+SAPHanaFilter="RA-ACT-DEC-LPA"
 
 
 if [ $# -ne 1 ]

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -2868,7 +2868,7 @@ SAPSTARTSRV=""
 SAPCONTROL=""
 DIR_PROFILE=""
 SAPSTARTPROFILE=""
-SAPHanaFilter="RA-ACT-DEC-LPA"
+declare -u SAPHanaFilter='ra-act-dec-lpa'
 
 
 if [ $# -ne 1 ]

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -92,9 +92,9 @@ function super_ocf_log() {
             none )
                 skip=1
                 ;;
-            * ) mtype=${message%% *}
+            * ) mtype=${message:0:4}
+                mtype=${mtype%% *}
                 mtype=${mtype%:}
-                mtype=${mtype#fh}
                 [[ ${shf} == *${mtype}* ]] && skip=0 || skip=1
             ;;
         esac

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -74,9 +74,9 @@ function super_ocf_log() {
             none )
                 skip=1
                 ;;
-            * ) mtype=${message%% *}
+            * ) mtype=${message:0:4}
+                mtype=${mtype%% *}
                 mtype=${mtype%:}
-                mtype=${mtype#fh}
                 [[ ${shf} == *${mtype}* ]] && skip=0 || skip=1
             ;;
         esac

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -54,17 +54,15 @@ SH=/bin/sh
 #
 # function: super_ocf_log - wrapper function for ocf log in order catch usual logging into super log
 # params:   LOG_MESSAGE
-# globals:  SUPER_LOG_PATH, SAPHanaFilter
+# globals:  SAPHanaFilter
 function super_ocf_log() {
     local level="$1"
     local message="$2"
     local skip=1
     local mtype=""
-    local search=0
     local shf="${SAPHanaFilter:-all}"
     #ocf_log "info" "super_ocf_log: f:$shf l:$level m:$message"
     # message levels: (dbg)|info|warn|err|error
-    #
     # message types:  (ACT|RA|FLOW|DBG|LPA|DEC
     case "$level" in
         dbg | debug | warn | err | error ) skip=0
@@ -79,12 +77,7 @@ function super_ocf_log() {
             * ) mtype=${message%% *}
                 mtype=${mtype%:}
                 mtype=${mtype#fh}
-                echo "$shf"|  grep -iq ${mtype}; search=$?
-                if [ $search -eq 0 ]; then
-                     skip=0
-                else
-                    skip=1
-                fi
+                [[ ${shf} == *${mtype}* ]] && skip=0 || skip=1
             ;;
         esac
         ;;
@@ -1131,7 +1124,8 @@ sidadm=""
 InstanceName=""
 InstanceNr=""
 DIR_EXECUTABLE=""
-SAPHanaFilter="ra-act-dec-lpa"
+SAPHanaFilter="RA-ACT-DEC-LPA"
+
 
 if [ $# -ne 1 ]
 then

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -1124,7 +1124,7 @@ sidadm=""
 InstanceName=""
 InstanceNr=""
 DIR_EXECUTABLE=""
-SAPHanaFilter="RA-ACT-DEC-LPA"
+declare -u SAPHanaFilter='ra-act-dec-lpa'
 
 
 if [ $# -ne 1 ]


### PR DESCRIPTION
super_ocf_log is a central function for logging - each message is checked by grep to decide if filtered out or not. This external call to grep is causing a fork and several syscalls. All can be efficiently done within bash.

120 Calls to super_ocf_log - 'strace -c' - time

orig
```console
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
100.00    0.102206                 13802      1274 total

real    0m0.231s
user    0m0.164s
sys     0m0.104s

```
new
```console
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
100.00    0.001009                   247        14 total

real    0m0.020s
user    0m0.016s
sys     0m0.004s
```
[test_super_ocf_log_new.sh.txt](https://github.com/SUSE/SAPHanaSR/files/9530652/test_super_ocf_log_new.sh.txt)
[test_super_ocf_log_orig.sh.txt](https://github.com/SUSE/SAPHanaSR/files/9530653/test_super_ocf_log_orig.sh.txt)
