### PR TITLE
add the changes recommended from SAP in the PR#119, PR#118 and PR#117

### DIFF
--- a/SAPHanaSR.changes_12
+++ b/SAPHanaSR.changes_12
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Tue Aug 16 16:22:44 UTC 2022 - abriel@suse.com
+Thu Sep 22 17:09:06 UTC 2022 - abriel@suse.com
 
 - Version bump to 0.161.1 - Testversion
 - add the required 'xmllint' to the package
@@ -17,7 +17,11 @@ Tue Aug 16 16:22:44 UTC 2022 - abriel@suse.com
   (bsc#1198127)
 - add new HA/DR provider hook susChkSrv
   (jsc#PED-1241, jsc#PED-1240)
+- add new tool SAPHanaSR-manageProvider to show, add and delete
+  HA/DR provider sections in the global.ini of SAP HANA.
 - update suse icon to new branding
+- improve runtime behaviour by removing redundant HDBSettings.sh
+  calls and avoid 'HDB version' calls if possible
 
 -------------------------------------------------------------------
 Wed Jun  1 13:56:01 UTC 2022 - abriel@suse.com

--- a/SAPHanaSR.changes_15
+++ b/SAPHanaSR.changes_15
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Tue Aug 16 16:22:44 UTC 2022 - abriel@suse.com
+Thu Sep 22 17:09:06 UTC 2022 - abriel@suse.com
 
 - Version bump to 0.161.1 - Testversion
 - add the required 'xmllint' to the package
@@ -17,7 +17,11 @@ Tue Aug 16 16:22:44 UTC 2022 - abriel@suse.com
   (bsc#1198127)
 - add new HA/DR provider hook susChkSrv
   (jsc#PED-1241, jsc#PED-1240)
+- add new tool SAPHanaSR-manageProvider to show, add and delete
+  HA/DR provider sections in the global.ini of SAP HANA.
 - update suse icon to new branding
+- improve runtime behaviour by removing redundant HDBSettings.sh
+  calls and avoid 'HDB version' calls if possible
 
 -------------------------------------------------------------------
 Wed Jun  1 13:56:01 UTC 2022 - abriel@suse.com

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -78,8 +78,8 @@ function super_ocf_log() {
     local message="$2"
     local skip=1
     local mtype=""
-    local search=0
     local shf="${SAPHanaFilter:-all}"
+    #ocf_log "info" "super_ocf_log: f:$shf l:$level m:$message"
     # message levels: (dbg)|info|warn|err|error
     # message types:  (ACT|RA|FLOW|DBG|LPA|DEC|DBG2...
     case "$level" in
@@ -92,15 +92,10 @@ function super_ocf_log() {
             none )
                 skip=1
                 ;;
-            * ) mtype=${message%% *}
+            * ) mtype=${message:0:4}
+                mtype=${mtype%% *}
                 mtype=${mtype%:}
-                mtype=${mtype#fh}
-                echo "$shf"|  grep -iq ${mtype}; search=$?
-                if [ $search -eq 0 ]; then
-                     skip=0
-                else
-                    skip=1
-                fi
+                [[ ${shf} == *${mtype}* ]] && skip=0 || skip=1
             ;;
         esac
         ;;
@@ -675,7 +670,7 @@ function HANA_CALL()
     fi
     case $timeOut in
         0 | inf )
-                  output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
+                  output=$($pre_cmd "$pre_script; $cmd"); rc=$?
                   ;;
         *       )
                   errExt=$(date '+%s%N')_${sid}adm
@@ -683,7 +678,7 @@ function HANA_CALL()
                   cmd_out_log=/tmp/HANA_CALL_CMD_RA_OUT_${errExt}
                   cmd_err_log=/tmp/HANA_CALL_CMD_RA_${errExt}
 
-                  output=$(timeout --foreground -s 9 "$timeOut" $pre_cmd "($pre_script; timeout -s 9 $timeOut /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd > $cmd_out_log) >& $cmd_err_log" 2>"$su_err_log"); rc=$?
+                  output=$(timeout --foreground -s 9 "$timeOut" $pre_cmd "($pre_script; timeout -s 9 $timeOut $cmd > $cmd_out_log) >& $cmd_err_log" 2>"$su_err_log"); rc=$?
 
                   output=$(if [ -f "$cmd_out_log" ]; then cat "$cmd_out_log"; rm -f "$cmd_out_log"; fi)
                   suErr=$(if [ -f "$su_err_log" ]; then cat "$su_err_log"; rm -f "$su_err_log"; else echo "NA"; fi)
@@ -695,7 +690,7 @@ function HANA_CALL()
                       if [ "$cmdErr" == "NA" ]; then
                           # seems something was going wrong with the 'pre_cmd' (su)
                           super_ocf_log warn "DEC: HANA_CALL returned '1' for command '$pre_cmd'. Retry once."
-                          output=$(timeout --foreground -s 9 "$timeOut" $pre_cmd "$pre_script; timeout -s 9 $timeOut /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
+                          output=$(timeout --foreground -s 9 "$timeOut" $pre_cmd "$pre_script; timeout -s 9 $timeOut $cmd"); rc=$?
                       fi
                   fi
                   #
@@ -706,7 +701,7 @@ function HANA_CALL()
                   fi
                   if [ $rc -eq 124 -a -n "$onTimeOut" ]; then
                       local second_output=""
-                      second_output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $onTimeOut");
+                      second_output=$($pre_cmd "$pre_script; $onTimeOut");
                   fi
                  ;;
     esac
@@ -990,18 +985,25 @@ function saphana_init() {
         SAPSTARTPROFILE="$(ls -1 $DIR_PROFILE/${OCF_RESKEY_INSTANCE_PROFILE:-${SID}_${InstanceName}_*})"
     fi
     #PATH=${PATH}:${DIR_EXECUTABLE}; export PATH
+    #
+    # get HANA version
+    #
     local ges_ver
-    ges_ver=$(HANA_CALL --timeout 10 --cmd "HDB version" | tr -d " " | awk -F: '$1 == "version" {print $2}')
-    hdbver=${ges_ver%.*.*}
+    ges_ver=$(grep -s -m1 -oP 'fullversion: \K.+(?= Build)' "/usr/sap/$SID/$InstanceName/exe/manifest")
+    #fallback
+    [[ -z ${ges_ver:-} ]] && ges_ver=$(HANA_CALL --timeout 10 --cmd "HDB version" | tr -d " " | awk -F: '$1 == "version" {print $2}')
+    #Version xx.yy.zzz
+    [[ ${ges_ver} =~ [0-9]+(\.[0-9]+){2} ]] && hdbver=${BASH_REMATCH[0]}
+
     #
     # since rev 111.00 we should use a new hdbnsutil option to get the -sr_state
     # since rev 112.03 the old option is changed and we should use -sr_stateConfiguration where ever possible
     #
-    hdbState="hdbnsutil -sr_state"
-    hdbMap="hdbnsutil -sr_state"
-    if version "$hdbver" ">=" "1.00.111"; then
-        hdbState="hdbnsutil -sr_stateConfiguration"
-        hdbMap="hdbnsutil -sr_stateHostMapping"
+    hdbState="hdbnsutil -sr_stateConfiguration"
+    hdbMap="hdbnsutil -sr_stateHostMapping"
+    if version "$hdbver" "<" "1.00.111"; then
+        hdbState="hdbnsutil -sr_state"
+        hdbMap="hdbnsutil -sr_state"
     fi
     super_ocf_log info "FLOW $FUNCNAME rc=$OCF_SUCCESS"
     return $OCF_SUCCESS
@@ -1223,7 +1225,7 @@ function check_for_primary() {
                 # fallback for 'hdbnsutil' failing 3 times.
                 local gpKeys=""
                 gpKeys=$(echo --key=global.ini/system_replication/{actual_mode,mode})
-                node_full_status=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "HDBSettings.sh getParameter.py $gpKeys --sapcontrol=1" 2>&1 | awk -F/ 'BEGIN {out=0} /^SAPCONTROL-OK: <begin>/ { out=1 } /^SAPCONTROL-OK: <end>/ { out=0 } /=/ {if (out==1) {print $3} }')
+                node_full_status=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "cdpy; python getParameter.py $gpKeys --sapcontrol=1" 2>&1 | awk -F/ 'BEGIN {out=0} /^SAPCONTROL-OK: <begin>/ { out=1 } /^SAPCONTROL-OK: <end>/ { out=0 } /=/ {if (out==1) {print $3} }')
                 # first try to get the value of 'actual_mode' from the global.ini
                 ini_mode=$(echo "$node_full_status" | awk -F= '$1=="actual_mode" {print $2}')
                 # if 'actual_mode' is not available, fallback to 'mode'
@@ -1288,8 +1290,7 @@ function analyze_hana_sync_statusSRS()
     # TODO: Check beginning from which SPS does SAP support HDBSettings.sh?
     # TODO: Limit the runtime of systemReplicationStatus.py
     # SAP_CALL
-    # FULL_SR_STATUS=$(su - $sidadm -c "python $DIR_EXECUTABLE/python_support/systemReplicationStatus.py $siteParam" 2>/dev/null); srRc=$?
-    FULL_SR_STATUS=$(HANA_CALL --timeout 5 --cmd "systemReplicationStatus.py $siteParam" 2>/dev/null); srRc=$?
+    FULL_SR_STATUS=$(HANA_CALL --timeout 5 --cmd "cdpy; python systemReplicationStatus.py $siteParam" 2>/dev/null); srRc=$?
     super_ocf_log info "DEC $FUNCNAME systemReplicationStatus.py (to site '$remSR_name')-> $srRc"
     super_ocf_log info "FLOW $FUNCNAME systemReplicationStatus.py (to site '$remSR_name')-> $srRc"
     #
@@ -1428,12 +1429,12 @@ function get_hana_landscape_status()
     # SAPSYSTEMNAME=SLE /usr/sap/SLE/HDB00/HDBSettings.sh landscapeHostConfiguration.py
     # TODO: Check beginning from which SPS does SAP support HDBSettings.sh?
     # DONE: Limit the runtime of landscapeHostConfiguration.py
-    HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "landscapeHostConfiguration.py" 1>/dev/null 2>/dev/null; rc=$?
+    HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "cdpy; python landscapeHostConfiguration.py" 1>/dev/null 2>/dev/null; rc=$?
     if [ $rc -eq 124 ]; then
         # TODO: PRIO 1: Check, if we should loop here like 'for i in 1 2 3 ...' ?
         # landscape timeout
         sleep 20
-        HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "landscapeHostConfiguration.py" 1>/dev/null 2>/dev/null; rc=$?
+        HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "cdpy; python landscapeHostConfiguration.py" 1>/dev/null 2>/dev/null; rc=$?
         if [ $rc -eq 124 ]; then
            # TODO PRIO2: How to handle still hanging lss - current solution is to say "FATAL"
            rc=0
@@ -2640,7 +2641,7 @@ function saphana_monitor_secondary()
             local hanaOut1=""
             # TODO: PRIO 3: check, if using getParameter.py is the best option to analyze the set operationMode
             # DONE: PRIO 3: Should we default to logreplay for SAP HANA >= SPS11 ?
-            hanaOut1=$(HANA_CALL --timeout 10 --use-su --cmd "getParameter.py --key=global.ini/system_replication/operation_mode --sapcontrol=1")
+            hanaOut1=$(HANA_CALL --timeout 10 --use-su --cmd "cdpy; python getParameter.py --key=global.ini/system_replication/operation_mode --sapcontrol=1")
             hanaFilter1=$(echo "$hanaOut1" | awk -F/ 'BEGIN {out=0} /^SAPCONTROL-OK: <begin>/ { out=1 } /^SAPCONTROL-OK: <end>/ { out=0 } /=/ {if (out==1) {print $3} }')
             hanaOM=$(echo "$hanaFilter1" | awk -F= '$1=="operation_mode" {print $2}')
             set_hana_attribute "${NODENAME}" "$hanaOM" "${ATTR_NAME_HANA_OPERATION_MODE[@]}"
@@ -2873,8 +2874,7 @@ SAPSTARTSRV=""
 SAPCONTROL=""
 DIR_PROFILE=""
 SAPSTARTPROFILE=""
-SAPHanaFilter="ra-act-dec-lpa"
-
+declare -u SAPHanaFilter='ra-act-dec-lpa'
 
 
 if [ $# -ne 1 ]

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -54,17 +54,15 @@ SH=/bin/sh
 #
 # function: super_ocf_log - wrapper function for ocf log in order catch usual logging into super log
 # params:   LOG_MESSAGE
-# globals:  SUPER_LOG_PATH, SAPHanaFilter
+# globals:  SAPHanaFilter
 function super_ocf_log() {
     local level="$1"
     local message="$2"
     local skip=1
     local mtype=""
-    local search=0
     local shf="${SAPHanaFilter:-all}"
     #ocf_log "info" "super_ocf_log: f:$shf l:$level m:$message"
     # message levels: (dbg)|info|warn|err|error
-    #
     # message types:  (ACT|RA|FLOW|DBG|LPA|DEC
     case "$level" in
         dbg | debug | warn | err | error ) skip=0
@@ -76,15 +74,10 @@ function super_ocf_log() {
             none )
                 skip=1
                 ;;
-            * ) mtype=${message%% *}
+            * ) mtype=${message:0:4}
+                mtype=${mtype%% *}
                 mtype=${mtype%:}
-                mtype=${mtype#fh}
-                echo "$shf"|  grep -iq ${mtype}; search=$?
-                if [ $search -eq 0 ]; then
-                     skip=0
-                else
-                    skip=1
-                fi
+                [[ ${shf} == *${mtype}* ]] && skip=0 || skip=1
             ;;
         esac
         ;;
@@ -425,7 +418,7 @@ function HANA_CALL()
     fi
     case $timeOut in
         0 | inf )
-                  output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
+                  output=$($pre_cmd "$pre_script; $cmd"); rc=$?
                   ;;
         *       )
                   errExt=$(date '+%s%N')_${sid}adm
@@ -433,7 +426,7 @@ function HANA_CALL()
                   cmd_out_log=/tmp/HANA_CALL_CMD_TOP_OUT_${errExt}
                   cmd_err_log=/tmp/HANA_CALL_CMD_TOP_${errExt}
 
-                  output=$(timeout "$timeOut" $pre_cmd "($pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd > $cmd_out_log) >& $cmd_err_log" 2>"$su_err_log"); rc=$?
+                  output=$(timeout "$timeOut" $pre_cmd "($pre_script; $cmd > $cmd_out_log) >& $cmd_err_log" 2>"$su_err_log"); rc=$?
 
                   output=$(if [ -f "$cmd_out_log" ]; then cat "$cmd_out_log"; rm -f "$cmd_out_log"; fi)
                   suErr=$(if [ -f "$su_err_log" ]; then cat "$su_err_log"; rm -f "$su_err_log"; else echo "NA"; fi)
@@ -445,7 +438,7 @@ function HANA_CALL()
                       if [ "$cmdErr" == "NA" ]; then
                           # seems something was going wrong with the 'pre_cmd' (su)
                           super_ocf_log warn "DEC: HANA_CALL returned '1' for command '$pre_cmd'. Retry once."
-                          output=$(timeout "$timeOut" $pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
+                          output=$(timeout "$timeOut" $pre_cmd "$pre_script; $cmd"); rc=$?
                       fi
                   fi
                   #
@@ -456,7 +449,7 @@ function HANA_CALL()
                   fi
                   if [ $rc -eq 124 -a -n "$onTimeOut" ]; then
                       local second_output=""
-                      second_output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $onTimeOut");
+                      second_output=$($pre_cmd "$pre_script; $onTimeOut");
                   fi
                  ;;
     esac
@@ -558,17 +551,21 @@ function sht_init() {
     # get HANA version
     #
     local ges_ver
-    ges_ver=$(HANA_CALL --timeout 10 --cmd "HDB version" | tr -d " " | awk -F: '$1 == "version" {print $2}')
-    hdbver=${ges_ver%.*.*}
+    ges_ver=$(grep -s -m1 -oP 'fullversion: \K.+(?= Build)' "/usr/sap/$SID/$InstanceName/exe/manifest")
+    #fallback
+    [[ -z ${ges_ver:-} ]] && ges_ver=$(HANA_CALL --timeout 10 --cmd "HDB version" | tr -d " " | awk -F: '$1 == "version" {print $2}')
+    #Version xx.yy.zzz
+    [[ ${ges_ver} =~ [0-9]+(\.[0-9]+){2} ]] && hdbver=${BASH_REMATCH[0]}
+
     #
     # since rev 111.00 we should use a new hdbnsutil option to get the -sr_state
     # since rev 112.03 the old option is changed and we should use -sr_stateConfiguration where ever possible
     #
-    hdbState="hdbnsutil -sr_state"
-    hdbMap="hdbnsutil -sr_state"
-    if version "$hdbver" ">=" "1.00.111"; then
-        hdbState="hdbnsutil -sr_stateConfiguration"
-        hdbMap="hdbnsutil -sr_stateHostMapping"
+    hdbState="hdbnsutil -sr_stateConfiguration"
+    hdbMap="hdbnsutil -sr_stateHostMapping"
+    if version "$hdbver" "<" "1.00.111"; then
+        hdbState="hdbnsutil -sr_state"
+        hdbMap="hdbnsutil -sr_state"
     fi
     #### SAP-CALL
     # hdbnsutil was a bit unstable in some tests so we recall the tool, if it fails to report the srmode
@@ -582,7 +579,7 @@ function sht_init() {
             gP ) # call getParameter (gP)
                 local gpKeys=""
                 gpKeys=$(echo --key=global.ini/system_replication/{actual_mode,mode,site_name,site_id})
-                hdbANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "HDBSettings.sh getParameter.py $gpKeys --sapcontrol=1" 2>&1 | awk -F/ 'BEGIN {out=0} /^SAPCONTROL-OK: <begin>/ { out=1 } /^SAPCONTROL-OK: <end>/ { out=0 } /=/ {if (out==1) {print $3} }')
+                hdbANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "cdpy; python getParameter.py $gpKeys --sapcontrol=1" 2>&1 | awk -F/ 'BEGIN {out=0} /^SAPCONTROL-OK: <begin>/ { out=1 } /^SAPCONTROL-OK: <end>/ { out=0 } /=/ {if (out==1) {print $3} }')
                 srmode=$(echo "$hdbANSWER" | awk -F= '$1=="actual_mode" {print $2}')
                 # if 'actual_mode' is not available, fallback to 'mode'
                 if [ -z "$srmode" ]; then
@@ -1014,7 +1011,9 @@ function sht_monitor_clone() {
 	if ocf_is_probe; then
 		super_ocf_log debug "DBG: PROBE ONLY"
         sht_monitor; rc=$?
-        local hana_version=$(HANA_CALL --timeout 10 --cmd "HDB version" \
+        local hana_version
+        hana_version=$(grep -s -m1 -oP 'fullversion: \K.+(?= Build)' "/usr/sap/$SID/$InstanceName/exe/manifest")
+        [[ -z ${hana_version:-} ]] && hana_version=$(HANA_CALL --timeout 10 --cmd "HDB version" \
             | awk -F':' '$1=="  version" {print $2}; ' | tr -d '[:space:]')
         if [[ -n $hana_version ]]; then
             set_hana_attribute "${NODENAME}" "$hana_version" ${ATTR_NAME_HANA_VERSION[@]}
@@ -1077,11 +1076,11 @@ function sht_monitor_clone() {
     #
     setRole=true
     if version "$hdbver" ">=" "1.00.100"; then
-        hanaANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "landscapeHostConfiguration.py --sapcontrol=1" 2>/dev/null); hanalrc="$?"
+        hanaANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "cdpy; python landscapeHostConfiguration.py --sapcontrol=1" 2>/dev/null); hanalrc="$?"
         # retry command, if a timeout occurred
         if [ "$hanalrc" -ge 124 ]; then
             super_ocf_log warn "HANA_CALL timed out after $HANA_CALL_TIMEOUT seconds running command 'landscapeHostConfiguration.py --sapcontrol=1'. Retrying..."
-            hanaANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "landscapeHostConfiguration.py --sapcontrol=1" 2>/dev/null); hanalrc="$?"
+            hanaANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "cdpy; python landscapeHostConfiguration.py --sapcontrol=1" 2>/dev/null); hanalrc="$?"
             # if the second try again run into a timeout, log an error and do not set hanarole but keep the previous settings.
             if [ "$hanalrc" -ge 124 ]; then
                 super_ocf_log err "HANA_CALL Operation timeout after $HANA_CALL_TIMEOUT seconds running command 'landscapeHostConfiguration.py --sapcontrol=1'."
@@ -1100,11 +1099,11 @@ function sht_monitor_clone() {
         #
         # old code for backward compatibility
         #
-        hanaANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "landscapeHostConfiguration.py" 2>/dev/null); hanalrc="$?"
+        hanaANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "cdpy; python landscapeHostConfiguration.py" 2>/dev/null); hanalrc="$?"
         # retry command, if a timeout occurred
         if [ "$hanalrc" -ge 124 ]; then
             super_ocf_log warn "HANA_CALL timed out after $HANA_CALL_TIMEOUT seconds running command 'landscapeHostConfiguration.py'. Retrying..."
-            hanaANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "landscapeHostConfiguration.py" 2>/dev/null); hanalrc="$?"
+            hanaANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "cdpy; python landscapeHostConfiguration.py" 2>/dev/null); hanalrc="$?"
             # if the second try again run into a timeout, log an error and do not set hanarole but keep the previous settings.
             if [ "$hanalrc" -ge 124 ]; then
                 super_ocf_log err "HANA_CALL Operation timeout after $HANA_CALL_TIMEOUT seconds running command 'landscapeHostConfiguration.py'."
@@ -1172,7 +1171,8 @@ sidadm=""
 InstanceName=""
 InstanceNr=""
 DIR_EXECUTABLE=""
-SAPHanaFilter="ra-act-dec-lpa"
+declare -u SAPHanaFilter='ra-act-dec-lpa'
+
 
 if [ $# -ne 1 ]
 then


### PR DESCRIPTION
refresh the changelog files and

#119
super_ocf_log - get rid of external grep call; harmonize SAPHana/SAPHanaTopo
logy
SAPHanaFilter should be specified lower|uppercase

#118
get rid of additional HDBSettings.sh call
adjust python scripts calls by cdpy; python

#117
refactor HANA version
use manifest file - avoid su - sidadm and environment loading
use HDB version as fallback
flip test for version - assume newer version is default