### PR TITLE
Scoring crm master

### DIFF
--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -588,19 +588,16 @@ scoring_crm_master()
     super_ocf_log info "FLOW ${FUNCNAME[0]} ($*)"
     local roles="$1"
     local sync="$2"
-    local skip=0
     local myScore=""
     for scan in "${SCORING_TABLE[@]}"; do
-        if [ $skip -eq 0 ]; then
             read rolePatt syncPatt score <<< $scan
             if grep "$rolePatt" <<< "$roles"; then
                if grep "$syncPatt" <<< "$sync"; then
                   super_ocf_log info "DEC: scoring_crm_master: roles($roles) are matching pattern ($rolePatt)"
                   super_ocf_log info "DEC: scoring_crm_master: sync($sync) is matching syncPattern ($syncPatt)"
                   super_ocf_log info "DEC: scoring_crm_master: set score $score"
-                  skip=1
                   myScore=$score
-               fi
+                break
             fi
         fi
     done

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -588,15 +588,15 @@ scoring_crm_master()
     super_ocf_log info "FLOW ${FUNCNAME[0]} ($*)"
     local roles="$1"
     local sync="$2"
-    local myScore=""
+    local myScore=''
     for scan in "${SCORING_TABLE[@]}"; do
-            read rolePatt syncPatt score <<< $scan
             if grep "$rolePatt" <<< "$roles"; then
                if grep "$syncPatt" <<< "$sync"; then
-                  super_ocf_log info "DEC: scoring_crm_master: roles($roles) are matching pattern ($rolePatt)"
-                  super_ocf_log info "DEC: scoring_crm_master: sync($sync) is matching syncPattern ($syncPatt)"
-                  super_ocf_log info "DEC: scoring_crm_master: set score $score"
-                  myScore=$score
+        read rolePatt syncPatt score <<< $scan
+                super_ocf_log info "DEC: scoring_crm_master: roles($roles) are matching pattern ($rolePatt)"
+                super_ocf_log info "DEC: scoring_crm_master: sync($sync) is matching syncPattern ($syncPatt)"
+                super_ocf_log info "DEC: scoring_crm_master: set score $score"
+                myScore=$score
                 break
             fi
         fi

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -590,9 +590,9 @@ scoring_crm_master()
     local sync="$2"
     local myScore=''
     for scan in "${SCORING_TABLE[@]}"; do
-            if grep "$rolePatt" <<< "$roles"; then
-               if grep "$syncPatt" <<< "$sync"; then
         read rolePatt syncPatt score <<< $scan
+        if [[ "$roles" =~ $rolePatt ]] ; then
+            if [[ "$sync" =~ $syncPatt ]] ; then
                 super_ocf_log info "DEC: scoring_crm_master: roles($roles) are matching pattern ($rolePatt)"
                 super_ocf_log info "DEC: scoring_crm_master: sync($sync) is matching syncPattern ($syncPatt)"
                 super_ocf_log info "DEC: scoring_crm_master: set score $score"


### PR DESCRIPTION
remove skip variable and use break; avoid unnecessary further looping
get rid of external grep and use bash regex (grep was anyway missing -q option)
fix block indentation after removing skip-if