### PR TITLE
Runtime - get rid of external calls to date and use bash internal SEC…

### DIFF
--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -44,7 +44,7 @@
 SAPHanaVersion="0.162.0"
 #
 # Initialization:
-timeB=$(date '+%s')
+timeB=${SECONDS}
 
 : ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}
 . ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
@@ -2954,7 +2954,7 @@ case "$ACTION" in
         ra_rc=$OCF_ERR_UNIMPLEMENTED
         ;;
 esac
-timeE=$(date '+%s')
+timeE=${SECONDS}
 (( timeR = timeE - timeB ))
 super_ocf_log debug "DBG: ==== SAPHanaFilter=$SAPHanaFilter"
 super_ocf_log info "RA ==== end action $ACTION$CLACT with rc=${ra_rc} ($SAPHanaVersion) (${timeR}s)===="

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -30,7 +30,7 @@
 SAPHanaTopologyVersion="0.162.0"
 #
 # Initialization:
-timeB=$(date '+%s')
+timeB=${SECONDS}
 
 : ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}
 . ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
@@ -1247,7 +1247,7 @@ case "$ACTION" in
         ra_rc=$OCF_ERR_UNIMPLEMENTED
         ;;
 esac
-timeE=$(date '+%s')
+timeE=${SECONDS}
 (( timeR = timeE - timeB ))
 super_ocf_log info "RA ==== end action $ACTION$CLACT with rc=${ra_rc} ($SAPHanaTopologyVersion) (${timeR}s)===="
 exit ${ra_rc}


### PR DESCRIPTION
…ONDS

each call to date takes 30-40ms and also includes fork/clone descriptor handling
SECONDS is anyway tracked by bash and therefore for free