### PR TITLE
SAPHanaTopology: fix for bsc#1207466 

### DIFF
--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -969,7 +969,7 @@ function sht_stop_clone() {
         timeout=$stdTimeOut
     fi
 
-    hanaANSWER=$(HANA_CALL --timeout "$timeout" --cmd "landscapeHostConfiguration.py --sapcontrol=1" 2>/dev/null); hanalrc="$?"
+    hanaANSWER=$(HANA_CALL --timeout "$timeout" --cmd "python landscapeHostConfiguration.py --sapcontrol=1" 2>/dev/null); hanalrc="$?"
     if [ "$hanalrc" -ge 124 ]; then
         # timeout of HANA_CALL, set role to '1:P:-:-:-:-' to get the
         # saphana_demote_clone to fail and stop the resource


### PR DESCRIPTION
- SAPHanaTopology fails fatal during cluster stop and stop action

The was a "python" command name missing.