### PR TITLE
srHook/susHanaSR.py: correct path for crm_attribute

### DIFF
--- a/srHook/susHanaSR.py
+++ b/srHook/susHanaSR.py
@@ -67,7 +67,7 @@ try:
                 myMSG = "### Ignoring bad SR status because of empty site name in call params ###"
                 self.tracer.info("{0}.{1}() {2}\n".format(self.__class__.__name__, method, myMSG))
             else:
-                myCMD = "sudo /usr/bin/crm_attribute -n hana_%s_site_srHook_%s -v %s -t crm_config -s SAPHanaSR" % (mysid, mySite, mySRS)
+                myCMD = "sudo /usr/sbin/crm_attribute -n hana_%s_site_srHook_%s -v %s -t crm_config -s SAPHanaSR" % (mysid, mySite, mySRS)
                 rc = os.system(myCMD)
                 myMSG = "CALLING CRM: <{0}> rc={1}".format(myCMD, rc)
                 self.tracer.info("{0}.{1}() {2}\n".format(self.__class__.__name__, method, myMSG))


### PR DESCRIPTION
susHanaSR.py used the wrong path to call crm_attribute. So in our test cluster always the fallback file was used.