### PR TITLE
man pages: examples changed from multi-state to promotable clone, typos fixed

### DIFF
--- a/man/SAPHanaSR-ScaleOut_basic_cluster.7
+++ b/man/SAPHanaSR-ScaleOut_basic_cluster.7
@@ -338,7 +338,7 @@ Linux cluster should be in the same range.
 .RE
 .PP
 
-\fB* cleanup SDB stonith resource after write failure\fR
+\fB* clean up SDB stonith resource after write failure\fR
 
 In rare cases the SBD stonith resource failes writing to the block device.
 After the root cause has been found and fixed, the failure message can be

--- a/man/SAPHanaSR-ScaleOut_basic_cluster.7
+++ b/man/SAPHanaSR-ScaleOut_basic_cluster.7
@@ -228,7 +228,7 @@ primitive rsc_ip_SLE_HDB00 IPAddr2 \\
 .br
 colocation col_ip_with_SLE_HDB00 \\
 .br
- 2000: rsc_ip_SLE_HDB00:Started msl_SAPHanaCon_SLE_HDB00:Master
+ 2000: rsc_ip_SLE_HDB00:Started mst_SAPHanaCon_SLE_HDB00:Master
 .RE
 .PP
 
@@ -250,7 +250,7 @@ primitive rsc_ip_ro_SLE_HDB00 IPAddr2 \\
 .br
 colocation col_ip_ro_with_secondary_SLE_HDB00 \\
 .br
- 2000: rsc_ip_ro_SLE_HDB00:Started msl_SAPHanaCon_SLE_HDB00:Slave
+ 2000: rsc_ip_ro_SLE_HDB00:Started mst_SAPHanaCon_SLE_HDB00:Slave
 .br
 location loc_ip_ro_not_master_SLE_HDB00 \\
 .br
@@ -286,7 +286,7 @@ group grp_ip_SLE_HDB00 rsc_lb_SLE_HDB00 rsc_ip_SLE_HDB00 \\
 .br 
 colocation col_ip_with_SLE_HDB00 \\
 .br
- 8000: grp_ip_SLE_HDB00:Started msl_SAPHanaCon_SLE_HDB00:Master
+ 8000: grp_ip_SLE_HDB00:Started mst_SAPHanaCon_SLE_HDB00:Master
 .RE
 .PP
 

--- a/man/SAPHanaSR-ScaleOut_basic_cluster.7
+++ b/man/SAPHanaSR-ScaleOut_basic_cluster.7
@@ -228,7 +228,7 @@ primitive rsc_ip_SLE_HDB00 IPAddr2 \\
 .br
 colocation col_ip_with_SLE_HDB00 \\
 .br
- 2000: rsc_ip_SLE_HDB00:Started mst_SAPHanaCon_SLE_HDB00:Master
+ 2000: rsc_ip_SLE_HDB00:Started mst_SAPHanaCon_SLE_HDB00:Promoted
 .RE
 .PP
 
@@ -250,7 +250,7 @@ primitive rsc_ip_ro_SLE_HDB00 IPAddr2 \\
 .br
 colocation col_ip_ro_with_secondary_SLE_HDB00 \\
 .br
- 2000: rsc_ip_ro_SLE_HDB00:Started mst_SAPHanaCon_SLE_HDB00:Slave
+ 2000: rsc_ip_ro_SLE_HDB00:Started mst_SAPHanaCon_SLE_HDB00:Demoted
 .br
 location loc_ip_ro_not_master_SLE_HDB00 \\
 .br
@@ -286,7 +286,7 @@ group grp_ip_SLE_HDB00 rsc_lb_SLE_HDB00 rsc_ip_SLE_HDB00 \\
 .br 
 colocation col_ip_with_SLE_HDB00 \\
 .br
- 8000: grp_ip_SLE_HDB00:Started mst_SAPHanaCon_SLE_HDB00:Master
+ 8000: grp_ip_SLE_HDB00:Started mst_SAPHanaCon_SLE_HDB00:Promoted
 .RE
 .PP
 

--- a/man/SAPHanaSR-showAttr.8
+++ b/man/SAPHanaSR-showAttr.8
@@ -187,7 +187,7 @@ See also AUTOMATED_REGISTER and DUPLICATE_PRIMARY_TIMEOUT in ocf_suse_SAPHanaCon
 .\" Value: [ \fIgeneration\fR ]
 .\" 
 .\" The RA generation attribute identifies which generation of the RA is running.
-.\" It helps determing RA's capabilities and performing cluster-wide upgrades of
+.\" It helps determining RA's capabilities and performing cluster-wide upgrades of
 .\" RA and srHook. The generation should be same for both on all nodes of the
 .\" Linux cluster after successful upgrade.
 .\" See also gsh below and SAPHanaSR-manageAttr(8).
@@ -198,7 +198,7 @@ See also AUTOMATED_REGISTER and DUPLICATE_PRIMARY_TIMEOUT in ocf_suse_SAPHanaCon
 .\" Value: [ \fIgeneration\fR ]
 .\" 
 .\" The srHook generation attribute identifies which generation of the srHook is running.
-.\" It helps determing srHook's capabilities and performing cluster-wide upgrades of
+.\" It helps determining srHook's capabilities and performing cluster-wide upgrades of
 .\" RA and srHook. E.g. starting with generation 2.0 the RA supports scale-out
 .\" multi-target system replication, which needs replacement of the old SAPHanaSR.py
 .\" by new SAPHanaSrMultiTarget.py.

--- a/man/SAPHanaSR_basic_cluster.7
+++ b/man/SAPHanaSR_basic_cluster.7
@@ -200,7 +200,7 @@ primitive rsc_ip_SLE_HDB00 IPAddr2 \\
 .br
 colocation col_ip_with_SLE_HDB00 \\
 .br
- 2000: rsc_ip_SLE_HDB00:Started mst_SAPHanaCon_SLE_HDB00:Master
+ 2000: rsc_ip_SLE_HDB00:Started mst_SAPHanaCon_SLE_HDB00:Promoted
 .RE
 .PP
 .\" TODO seamless maintenance IP location
@@ -221,7 +221,7 @@ primitive rsc_ip_ro_SLE_HDB00 IPAddr2 \\
 .br
 colocation col_ip_ro_with_secondary_SLE_HDB00 \\
 .br
- 2000: rsc_ip_ro_SLE_HDB00:Started mst_SAPHanaCon_SLE_HDB00:Slave
+ 2000: rsc_ip_ro_SLE_HDB00:Started mst_SAPHanaCon_SLE_HDB00:Demoted
 .br
 location loc_ip_ro_not_master_SLE_HDB00 \\
 .br
@@ -261,7 +261,7 @@ group grp_ip_SLE_HDB00 rsc_lb_SLE_HDB00 rsc_ip_SLE_HDB00 \\
 .br
 colocation col_ip_with_SLE_HDB00 \\
 .br
- 8000: grp_ip_SLE_HDB00:Started mst_SAPHanaCon_SLE_HDB00:Master
+ 8000: grp_ip_SLE_HDB00:Started mst_SAPHanaCon_SLE_HDB00:Promoted
 .RE
 .PP
 

--- a/man/SAPHanaSR_basic_cluster.7
+++ b/man/SAPHanaSR_basic_cluster.7
@@ -304,7 +304,7 @@ Linux cluster should be in the same range.
 .RE
 .PP
 
-\fB* cleanup SDB stonith resource after write failure\fR
+\fB* clean up SDB stonith resource after write failure\fR
 
 In rare cases the SBD stonith resource fails writing to the block device.
 After the root cause has been found and fixed, the failure message can be

--- a/man/SAPHanaSR_basic_cluster.7
+++ b/man/SAPHanaSR_basic_cluster.7
@@ -200,7 +200,7 @@ primitive rsc_ip_SLE_HDB00 IPAddr2 \\
 .br
 colocation col_ip_with_SLE_HDB00 \\
 .br
- 2000: rsc_ip_SLE_HDB00:Started msl_SAPHanaCon_SLE_HDB00:Master
+ 2000: rsc_ip_SLE_HDB00:Started mst_SAPHanaCon_SLE_HDB00:Master
 .RE
 .PP
 .\" TODO seamless maintenance IP location
@@ -221,7 +221,7 @@ primitive rsc_ip_ro_SLE_HDB00 IPAddr2 \\
 .br
 colocation col_ip_ro_with_secondary_SLE_HDB00 \\
 .br
- 2000: rsc_ip_ro_SLE_HDB00:Started msl_SAPHanaCon_SLE_HDB00:Slave
+ 2000: rsc_ip_ro_SLE_HDB00:Started mst_SAPHanaCon_SLE_HDB00:Slave
 .br
 location loc_ip_ro_not_master_SLE_HDB00 \\
 .br
@@ -261,7 +261,7 @@ group grp_ip_SLE_HDB00 rsc_lb_SLE_HDB00 rsc_ip_SLE_HDB00 \\
 .br
 colocation col_ip_with_SLE_HDB00 \\
 .br
- 8000: grp_ip_SLE_HDB00:Started msl_SAPHanaCon_SLE_HDB00:Master
+ 8000: grp_ip_SLE_HDB00:Started mst_SAPHanaCon_SLE_HDB00:Master
 .RE
 .PP
 

--- a/man/SAPHanaSR_maintenance_examples.7
+++ b/man/SAPHanaSR_maintenance_examples.7
@@ -92,7 +92,7 @@ The SAP HANA resources are set into maintenance, an sr_takeover is performed,
 the old primary is registered as new secondary.
 Therefore the correct secondary site name has to be used, see later example.
 Finally the SAP HANA resources are given back to the Linux cluster.
-See also section REQUIREMENTS below and later example on determining the correct site name.
+See also section REQUIREMENTS below and later example on determing the correct site name.
 .PP
 .RS 2
 1. On either node
@@ -194,7 +194,7 @@ The SAP HANA resources are set into maintenance, an sr_takeover is performed
 with suspending the primary, the old primary is registered as new secondary.
 Therefore the correct secondary site name has to be used.
 Finally the SAP HANA resources are given back to the Linux cluster.
-See also section REQUIREMENTS below and later example on determining the correct site name.
+See also section REQUIREMENTS below and later example on determing the correct site name.
 .PP
 .RS 2
 1. Check status of Linux cluster and HANA, show current site names.

--- a/man/SAPHanaSR_maintenance_examples.7
+++ b/man/SAPHanaSR_maintenance_examples.7
@@ -1,16 +1,16 @@
-.\" Version: 0.160.1
+.\" Version: 1.001 
 .\"
-.TH SAPHanaSR_maintenance_examples 7 "10 Feb 2023" "" "SAPHanaSR"
+.TH SAPHanaSR_maintenance_examples 7 "12 Jun 2023" "" "SAPHanaSR"
 .\"
 .SH NAME
-SAPHanaSR_maintenance_examples \- maintenance examples for SAPHana and SAPHanaController.
+SAPHanaSR_maintenance_examples \- maintenance examples for SAPHanaController.
 .PP
 .\"
 .SH DESCRIPTION
 .PP
-Maintenance examples for SAPHana and SAPHanaController.
-Please see ocf_suse_SAPHana(7) respectively ocf_suse_SAPHanaController(7),
-SAPHanaSR.py(7), SAPHanaSrMultiTarget.py(7), susTkOver.py(7), susChkSrv.py(7),
+Maintenance examples for SAPHanaController.
+Please see ocf_suse_SAPHanaController(7), susHanaSR.py(7),
+susHanaSrMultiTarget.py(7), susTkOver.py(7), susChkSrv.py(7),
 SAPHanaSR-manageAttr(8), for more examples and read the REQUIREMENTS section
 below.
 .RE
@@ -62,13 +62,13 @@ After takeover of the primary has been finished, the migration rule has to be de
 .br
 # cs_clusterstate -i
 .br
-# crm resource move msl_SAPHana_SLE_HDB10 force
+# crm resource move mst_SAPHana_SLE_HDB10 force
 .br
 # cs_clusterstate -i
 .br
 # SAPHanaSR-showAttr
 .br
-# crm resource clear msl_SAPHana_SLE_HDB10
+# crm resource clear mst_SAPHana_SLE_HDB10
 .br
 # SAPHanaSR-showAttr
 .br
@@ -102,7 +102,7 @@ See also section REQUIREMENTS below and later example on determining the correct
 .br
 If everything looks fine, proceed.
 .br
-# crm resource maintenance msl_SAPHana_SLE_HDB10
+# crm resource maintenance mst_SAPHana_SLE_HDB10
 .br
 # crm_mon -1r
 .RE
@@ -130,9 +130,9 @@ If everything looks fine, proceed.
 .br
 ~> hdbnsutil -sr_takeover
 .br
-~> HDBsettings.sh systemReplicationStatus.py; echo RC:$?
+~> cdpy; python3 ./systemReplicationStatus.py; echo RC:$?
 .br
-~> HDBsettings.sh landscapeHostConfiguration.py; echo RC:$?
+~> cdpy; python3 ./landscapeHostConfiguration.py; echo RC:$?
 .br
 If everything looks fine, proceed.
 .RE
@@ -153,9 +153,9 @@ If everything looks fine, proceed.
 .RE
 .RS 4
 .br
-~> HDBsettings.sh systemReplicationStatus.py; echo RC:$?
+~> cdpy; python3 ./systemReplicationStatus.py; echo RC:$?
 .br
-~> HDBsettings.sh ./landscapeConfigurationStatus.py; echo RC:$?
+~> cdpy; python3 ./landscapeConfigurationStatus.py; echo RC:$?
 .br
 ~> exit
 .br
@@ -168,9 +168,9 @@ If everything looks fine, proceed.
 .br
 # cs_clusterstate -i
 .br
-# crm resource refresh msl_SAPHana_SLE_HDB10
+# crm resource refresh mst_SAPHana_SLE_HDB10
 .br
-# crm resource maintenance msl_SAPHana_SLE_HDB10 off
+# crm resource maintenance mst_SAPHana_SLE_HDB10 off
 .br
 # SAPHanaSR-showAttr
 .br
@@ -227,90 +227,6 @@ This is an advanced task.
 .RE
 .PP
 .\"
-\fB*\fR Overview on maintenance procedure for HANA, the Linux cluster remains running, on pacemaker 1.0.
-
-See also section REQUIREMENTS below.
-.PP
-.RS 2
-1. Check if everything looks fine, see above.
-.br
-2. Set the Linux cluster into maintenance mode.
-.RE
-.RS 4
-# crm configure property maintenance-mode=true
-.RE
-.RS 2
-3. Perform the HANA maintenance, e.g. update to latest SPS.
-.br
-4. Set the SAPHanaController m/s resource to unmanaged.
-.RE
-.RS 4
-# crm resource unmanage <m/s-resource>
-.RE
-.RS 2
-5. Set the Linux cluster back into ready mode.
-.RE
-.RS 4
-# crm configure property maintenance-mode=false
-.RE
-.RS 2
-6. Clean up the SAPHanaController m/s resource.
-.RE
-.RS 4
-# crm resource cleanup <m/s-resource> node <node>
-.RE
-.RS 2
-7. Set the SAPHanaController m/s resource back to managed.
-.RE
-.RS 4
-# crm resource manage <m/s-resource>
-.RE
-.RS 2
-8. Check if everything looks fine, see above.
-.RE
-.PP
-.RE
-Note: The YaST module hana_updater does something similar, combined with an
-administrative takeover.
-.PP
-On pacemaker 1.1.19 and 2.0 respectively do the following. 
-.PP
-.RS 2
-1. Check if everything looks fine, see above.
-.br
-2. Set the SAPHanaController multi-state resource into maintenance mode.
-.RE
-.RS 4
-# crm resource maintenance msl_SAPHanaCon_SLE_HDB10 on
-.RE
-.RS 2
-3. Perform the HANA maintenance, e.g. update to latest SPS.
-.br
-4. Tell the cluster to forget about HANA status and to reprobe the resources.
-.RE
-.RS 4
-# crm resource refresh msl_SAPHanaCon_SLE_HDB10
-.RE
-.RS 2
-5. Set the SAPHanaController multi-state resource back to managed.
-.RE
-.RS 4
-# crm resource maintenance msl_SAPHanaCon_SLE_HDB10 off
-.RE
-.RS 2
-6. Remove the meta attribute from CIB, optional.
-.RE
-.RS 4
-# crm resource meta msl_SAPHanaCon_SLE_HDB10 delete maintenance
-.RE
-.RS 2
-7. Check if everything looks fine, see above.
-.RE
-.PP
-The two procedures must not be mixed. If the procedure for pacemaker-1.0 has
-been used, left-over maintenance attribute have to be removed from the CIB
-before proceeding with the new procedure for pacemaker-2.0.
-.PP
 \fB*\fR Overview on maintenance procedure for Linux, HANA remains running, on pacemaker-2.0.
 
 See also section REQUIREMENTS below and example on checking status of HANA and cluster above.
@@ -344,7 +260,7 @@ See also section REQUIREMENTS below and example on checking status of HANA and c
 .RS 4
 # crm resource refresh cln_...
 .br
-# crm resource refresh msl_...
+# crm resource refresh mst_...
 .RE
 .RS 2
 7. Set cluster ready for operations, on either node.
@@ -400,22 +316,22 @@ It also is necessary to test and document the whole procedure before applying in
 Note: HANA is not available from step 4 to step 9. 
 .RE
 .PP
-\fB*\fR Overview on update procedure for the SAPHanaSR and SAPHanaSR-ScaleOut package.
+\fB*\fR Overview on update procedure for the SAPHanaSR-angi package.
 
 This procedure can be used to update RAs, HANA HADR provider hook scripts and related tools while HANA and Linux cluster stay online. See also SAPHanaSR-manageAttr(8) for details on reloading the HANA HADR provider.
 .PP
 .RS 2
 1. Check status of Linux cluster and HANA, see above.
 .br
-2. Set resources SAPHana (or SAPHanaController) and SAPHanaTopology to maintenance.
+2. Set resources SAPHanaController and SAPHanaTopology to maintenance.
 .br
 3. Update RPM on all cluster nodes.
 .br
 4. Reload HANA HADR provider hook script on both sites.
 .br
-5. Refresh resources SAPHana (or SAPHanaController) and SAPHanaTopology.
+5. Refresh resources SAPHanaController and SAPHanaTopology.
 .br 
-6. Set resources SAPHana (or SAPHanaController) and SAPHanaTopology from maintenance to managed.
+6. Set resources SAPHanaController and SAPHanaTopology from maintenance to managed.
 .br
 7. Check status of Linux cluster and HANA, see above.
 .RE
@@ -467,6 +383,7 @@ See above overview on maintenance procedures whith running Linux cluster.
 .PP
 \fB*\fR Manually update global site attribute.
 
+.\" TODO: attributes still used for angi?
 In rare cases the global site attribute hana_<sid>_glob_prim or
 hana_<sid>_glob_sec is not updated automatically after successful takeover,
 while all other attributes are updated correctly. The global site attribute
@@ -527,7 +444,7 @@ l. Finally check if everything looks fine.
 .\"
 .SH REQUIREMENTS
 .br
-\fB*\fR For the current version of the resource agents that come with the software packages SAPHanaSR and SAPHanaSR-ScaleOut, the support is limited to the scenarios and parameters described in the respective manual pages SAPHanaSR(7) and SAPHanaSR-ScaleOut(7).
+\fB*\fR For the current version of the resource agents that come with the software packages SAPHanaSR-angi, the support is limited to the scenarios and parameters described in the respective manual pages SAPHanaSR-angi(7), SAPHanaSR(7) and SAPHanaSR-ScaleOut(7).
 .PP
 \fB*\fR Be patient. For detecting the overall HANA status, the Linux cluster
 needs a certain amount of time, depending on the HANA and the configured
@@ -539,7 +456,7 @@ landscape status, and the HANA SR status.
 .PP
 \fB*\fR Maintenance attributes for cluster, nodes and resources must not be mixed.
 .PP
-\fB*\fR The Linux cluster needs to be up and running to allow HA/DR provider events being written into CIB attributes. 
+\fB*\fR The Linux cluster needs to be up and running to allow HA/DR provider events being written into CIB attributes.
 The current HANA SR status might differ from CIB srHook attribute after Linux cluster maintenance.
 .PP
 \fB*\fR Manually activating an HANA primary, like start of HANA primary or takeover outside

--- a/man/SAPHanaSR_maintenance_examples.7
+++ b/man/SAPHanaSR_maintenance_examples.7
@@ -192,12 +192,12 @@ The status of HANA databases, system replication and Linux cluster has to be
 checked.
 The SAP HANA resources are set into maintenance, an sr_takeover is performed
 with suspending the primary, the old primary is registered as new secondary.
-Therefore the correct secondary site name has to be used, see later example.
+Therefore the correct secondary site name has to be used.
 Finally the SAP HANA resources are given back to the Linux cluster.
 See also section REQUIREMENTS below and later example on determining the correct site name.
 .PP
 .RS 2
-1. Check statuts of Linux cluster and HANA, show current site names.
+1. Check status of Linux cluster and HANA, show current site names.
 .br
 2. Set SAPHanaController multi-state resource into maintenance.
 .br

--- a/man/SAPHanaSR_maintenance_examples.7
+++ b/man/SAPHanaSR_maintenance_examples.7
@@ -48,8 +48,8 @@ This might be convenient when performing administrative actions or cluster tests
 
 
 This procedure does not work for scale-out. On scale-up, it will stop the HANA primary.
-This might take a while. If you want to avoid waiting for the stopped primary, use the
-below procedure which suspends the primary.
+This might take a while. If you want to avoid waiting for the stopped primary,
+use the below procedure which suspends the primary.
 If the cluster should also register the former primary as secondary, AUTOMATED_REGISTER="true" is needed. Before the takeover will be initiated, the status of the Linux cluster and the HANA system replication has to be checked. The takeover should be initiated as forced migration of the multi-state SAPHanaController resource.
 .br
 Not working: Regular migration, migration of IP address, migration of primitive SAPHanaController resource, setting primary node standby.
@@ -82,7 +82,7 @@ Note: Former versions of the Linux cluster used "migrate" instead of "move" and 
 .PP
 \fB*\fR Perform an SAP HANA takeover by using SAP tools. 
 
-The procedures is described here for scale-out. It works for scale-up as well. 
+The procedure is described here for scale-out. It works for scale-up as well. 
 The procedure will stop the HANA primary. This might take a while. If you want
 to avoid waiting for the stopped primary, use the below procedure which suspends
 the primary.

--- a/man/SAPHanaSR_maintenance_examples.7
+++ b/man/SAPHanaSR_maintenance_examples.7
@@ -92,7 +92,7 @@ The SAP HANA resources are set into maintenance, an sr_takeover is performed,
 the old primary is registered as new secondary.
 Therefore the correct secondary site name has to be used, see later example.
 Finally the SAP HANA resources are given back to the Linux cluster.
-See also section REQUIREMENTS below and later example on determing the correct site name.
+See also section REQUIREMENTS below and later example on determining the correct site name.
 .PP
 .RS 2
 1. On either node
@@ -194,7 +194,7 @@ The SAP HANA resources are set into maintenance, an sr_takeover is performed
 with suspending the primary, the old primary is registered as new secondary.
 Therefore the correct secondary site name has to be used.
 Finally the SAP HANA resources are given back to the Linux cluster.
-See also section REQUIREMENTS below and later example on determing the correct site name.
+See also section REQUIREMENTS below and later example on determining the correct site name.
 .PP
 .RS 2
 1. Check status of Linux cluster and HANA, show current site names.

--- a/man/SAPHanaSR_maintenance_examples.7
+++ b/man/SAPHanaSR_maintenance_examples.7
@@ -25,7 +25,7 @@ after something has been done. See also cs_show_saphanasr_status(8) and section
 REQUIREMENTS below.
 .PP
 .RS 4 
-# cs_clusterstate -a
+# cs_clusterstate -i
 .br
 # crm_mon -1r
 .br
@@ -44,12 +44,15 @@ This might be convenient when performing administrative actions or cluster tests
 # watch -n 9 "(crm_mon -1r;SAPHanaSR-showAttr;cs_clusterstate -i)|egrep -v'(^$|configured|###)'"
 .RE
 .PP
-\fB*\fR Initiate an administrative takeover of the HANA primary from one node to the other by using the Linux cluster. 
+\fB*\fR Initiate an administrative takeover of the HANA primary from one node to the other by using the Linux cluster.
 
-This procedure does not work for scale-out.
-If the cluster should also register the former primary as secondary, AUTOMATED_REGISTER="true" is needed. Before the takeover will be initiated, the status of the Linux cluster and the HANA system replication has to be checked. The takeover should be initiated as forced migration of the multi-state SAPHana resource.
+
+This procedure does not work for scale-out. On scale-up, it will stop the HANA primary.
+This might take a while. If you want to avoid waiting for the stopped primary, use the
+below procedure which suspends the primary.
+If the cluster should also register the former primary as secondary, AUTOMATED_REGISTER="true" is needed. Before the takeover will be initiated, the status of the Linux cluster and the HANA system replication has to be checked. The takeover should be initiated as forced migration of the multi-state SAPHanaController resource.
 .br
-Not working: Regular migration, migration of IP address, migration of primitive SAPHana resource, setting primary node standby.
+Not working: Regular migration, migration of IP address, migration of primitive SAPHanaController resource, setting primary node standby.
 .br
 After takeover of the primary has been finished, the migration rule has to be deleted. If AUTOMATED_REGISTER="true" is set, finally the former primary will be registered as secondary, once the migration rule has been deleted.
 .PP
@@ -62,13 +65,13 @@ After takeover of the primary has been finished, the migration rule has to be de
 .br
 # cs_clusterstate -i
 .br
-# crm resource move mst_SAPHana_SLE_HDB10 force
+# crm resource move mst_SAPHanaCon_SLE_HDB10 force
 .br
 # cs_clusterstate -i
 .br
 # SAPHanaSR-showAttr
 .br
-# crm resource clear mst_SAPHana_SLE_HDB10
+# crm resource clear mst_SAPHanaCon_SLE_HDB10
 .br
 # SAPHanaSR-showAttr
 .br
@@ -80,6 +83,9 @@ Note: Former versions of the Linux cluster used "migrate" instead of "move" and 
 \fB*\fR Perform an SAP HANA takeover by using SAP tools. 
 
 The procedures is described here for scale-out. It works for scale-up as well. 
+The procedure will stop the HANA primary. This might take a while. If you want
+to avoid waiting for the stopped primary, use the below procedure which suspends
+the primary.
 The status of HANA databases, system replication and Linux cluster has to be
 checked.
 The SAP HANA resources are set into maintenance, an sr_takeover is performed,
@@ -102,7 +108,7 @@ See also section REQUIREMENTS below and later example on determining the correct
 .br
 If everything looks fine, proceed.
 .br
-# crm resource maintenance mst_SAPHana_SLE_HDB10
+# crm resource maintenance mst_SAPHanaCon_SLE_HDB10
 .br
 # crm_mon -1r
 .RE
@@ -168,15 +174,54 @@ If everything looks fine, proceed.
 .br
 # cs_clusterstate -i
 .br
-# crm resource refresh mst_SAPHana_SLE_HDB10
+# crm resource refresh mst_SAPHanaCon_SLE_HDB10
 .br
-# crm resource maintenance mst_SAPHana_SLE_HDB10 off
+# crm resource maintenance mst_SAPHanaCon_SLE_HDB10 off
 .br
 # SAPHanaSR-showAttr
 .br
 # crm_mon -1r
 .br
 # cs_clusterstate -i
+.RE
+.PP
+\fB*\fR Overview on SAP HANA takeover using SAP tools and suspend primary feature.
+
+The procedure works for scale-up and scale-out.
+The status of HANA databases, system replication and Linux cluster has to be
+checked.
+The SAP HANA resources are set into maintenance, an sr_takeover is performed
+with suspending the primary, the old primary is registered as new secondary.
+Therefore the correct secondary site name has to be used, see later example.
+Finally the SAP HANA resources are given back to the Linux cluster.
+See also section REQUIREMENTS below and later example on determining the correct site name.
+.PP
+.RS 2
+1. Check statuts of Linux cluster and HANA, show current site names.
+.br
+2. Set SAPHanaController resource into maintenance.
+.br
+3. Perform the takeover, make sure to use the suspend primary feature:
+.RE
+.RS 4
+~> hdbnsutil -sr_takeover --suspendPrimary
+.RE
+.RS 2
+4. Check if the new primary is working.
+.br
+5. Stop suspended old primary.
+.br
+6. Register old primary as new secondary, make sure to use the correct site name.
+.br
+7. Start the new secondary.
+.br
+8. Check new secondary and its system replication.
+.br
+9. Refresh SAPHanaController resource.
+.br
+10. Set SAPHanaController resource to managed.
+.br
+11. Finally check status of Linux cluster and HANA. 
 .RE
 .PP
 \fB*\fR Check the two site names that are known to the Linux cluster. 

--- a/man/SAPHanaSR_maintenance_examples.7
+++ b/man/SAPHanaSR_maintenance_examples.7
@@ -199,7 +199,7 @@ See also section REQUIREMENTS below and later example on determining the correct
 .RS 2
 1. Check statuts of Linux cluster and HANA, show current site names.
 .br
-2. Set SAPHanaController resource into maintenance.
+2. Set SAPHanaController multi-state resource into maintenance.
 .br
 3. Perform the takeover, make sure to use the suspend primary feature:
 .RE
@@ -217,9 +217,9 @@ See also section REQUIREMENTS below and later example on determining the correct
 .br
 8. Check new secondary and its system replication.
 .br
-9. Refresh SAPHanaController resource.
+9. Refresh SAPHanaController multi-state resource.
 .br
-10. Set SAPHanaController resource to managed.
+10. Set SAPHanaController multi-state resource to managed.
 .br
 11. Finally check status of Linux cluster and HANA. 
 .RE

--- a/man/ocf_suse_SAPHana.7
+++ b/man/ocf_suse_SAPHana.7
@@ -275,7 +275,7 @@ In addition, a SAPHanaTopology clone resource is needed to make this work.
 .RE
 .PP
 .RS 2
-primitive rsc_SAPHana_SLE_HDB00 ocf:suse:SAPHana \\
+primitive rsc_SAPHanaCon_SLE_HDB00 ocf:suse:SAPHanaController \\
 .br
  op start interval="0" timeout="3600" \\
 .br
@@ -285,7 +285,7 @@ primitive rsc_SAPHana_SLE_HDB00 ocf:suse:SAPHana \\
 .br
  op demote interval="0" timeout="320" \\
 .br
- op monitor interval="60" role="Master" timeout="700" \\
+ op monitor interval="60" role="Promoted" timeout="700" \\
 .br
  op monitor interval="61" role="Slave" timeout="700" \\
 .br
@@ -293,9 +293,9 @@ primitive rsc_SAPHana_SLE_HDB00 ocf:suse:SAPHana \\
 .br
  DUPLICATE_PRIMARY_TIMEOUT="7200" AUTOMATED_REGISTER="false"
 .PP
-ms msl_SAPHana_SLE_HDB00 rsc_SAPHana_SLE_HDB00 \\
+clone mst_SAPHanaCon_SLE_HDB00 rsc_SAPHanaCon_SLE_HDB00 \\
 .br
- clone-max="2" clone-node-max="1"
+ meta clone-max="2" clone-node-max="1" interleave="true" promotable="true"
 .RE
 .PP
 * Below is an example configuration for the two SAPHana resources in a cost-optimized scenario.
@@ -312,7 +312,7 @@ gets a priority to allow priority fencing. See manual page
 SAPHanaSR_basic_cluster(7).
 .PP
 .RS 2
-primitive rsc_SAPHana_PRD_HDB10 ocf:suse:SAPHana \\
+primitive rsc_SAPHanaCon_PRD_HDB10 ocf:suse:SAPHanaController \\
 .br
  op start interval="0" timeout="3600" \\
 .br
@@ -322,7 +322,7 @@ primitive rsc_SAPHana_PRD_HDB10 ocf:suse:SAPHana \\
 .br
  op demote interval="0" timeout="320" \\
 .br
- op monitor interval="60" role="Master" timeout="700" \\
+ op monitor interval="60" role="Promoted" timeout="700" \\
 .br
  op monitor interval="61" role="Slave" timeout="700" \\
 .br
@@ -332,9 +332,9 @@ primitive rsc_SAPHana_PRD_HDB10 ocf:suse:SAPHana \\
 .br
  meta priority=100
 .PP
-ms msl_SAPHana_PRD_HDB10 rsc_SAPHana_PRD_HDB10 \\
+clone mst_SAPHanaCon_PRD_HDB10 rsc_SAPHanaCon_PRD_HDB10 \\
 .br
- clone-max="2" clone-node-max="1 interleave="true"
+ meta clone-max="2" clone-node-max="1 interleave="true" promotable="true"
 .PP
 primitive rsc_SAPInstance_TST_HDB10 ocf:heartbeat:SAPInstance \\
 .br
@@ -358,7 +358,7 @@ colocation col_TST_never_with_PRD-ip -inf: rsc_SAPInstance_TST_HDB20_node02:Star
 .PP
 order ord_TST_stop_before_PRD-promote inf: rsc_SAPInstance_TST_HDB20_node02:stop \\
 .br
- msl_SAPHana_PRD_HDB10:promote
+ mst_SAPHanaCon_PRD_HDB10:promote
 .RE
 .PP
 * Initiate an administrative takeover of the HANA primary from one node to the
@@ -380,13 +380,13 @@ Note: Older versions of the Linux cluster have used the commands 'migrate' and
 .br
 # crm configure show | grep cli
 .br
-# crm resource move msl_SAPHana_SLE_HDB10 force
+# crm resource move mst_SAPHanaCon_SLE_HDB10 force
 .br
 # cs_clusterstate -i
 .br
 # SAPHanaSR-showAttr
 .br
-# crm resource clear msl_SAPHana_SLE_HDB10 
+# crm resource clear mst_SAPHanaCon_SLE_HDB10 
 .RE
 .PP
 * Manually start the HANA primary if only one node is available.
@@ -433,13 +433,13 @@ property $id="SAPHanaSR" \\
 .\" TODO: output
 .RE
 .PP
-* Show failcount for resource rsc_SAPHana_HA1_HDB00 .
+* Show failcount for resource rsc_SAPHanaCon_HA1_HDB00 .
 
 See also cluster properties migration-threshold, failure-timeout and
 SAPHana parameter PREFER_SITE_TAKEOVER.
 .PP
 .RS 2
-# cibadmin -Ql | grep rsc_SAPHana_HA1_HDB00.*fail-count
+# cibadmin -Ql | grep rsc_SAPHanaCon_HA1_HDB00.*fail-count
 .\" TODO: crm_mon --failcounts 
 .RE
 .PP

--- a/man/ocf_suse_SAPHana.7
+++ b/man/ocf_suse_SAPHana.7
@@ -237,7 +237,7 @@ Suggested minimum timeout: 60\&.
 Reports whether the HANA instance seems to be working in multi-state it also needs to check the system replication status. Suggested minimum timeout: 700\&. Suggested interval: 60\&.
 .RE
 .PP
-\fBmonitor (Slave role)\fR
+\fBmonitor (demoted role)\fR
 .RS 4
 Reports whether the HANA instance seems to be working in multi-state it also needs to check the system replication status. The slave role's monitor interval has to be different from the master role. Suggested minimum timeout: 700\&. Suggested interval: 61\&.
 .RE
@@ -287,7 +287,7 @@ primitive rsc_SAPHanaCon_SLE_HDB00 ocf:suse:SAPHanaController \\
 .br
  op monitor interval="60" role="Promoted" timeout="700" \\
 .br
- op monitor interval="61" role="Slave" timeout="700" \\
+ op monitor interval="61" role="Started" timeout="700" \\
 .br
  params SID="SLE" InstanceNumber="00" PREFER_SITE_TAKEOVER="true" \\
 .br
@@ -324,7 +324,7 @@ primitive rsc_SAPHanaCon_PRD_HDB10 ocf:suse:SAPHanaController \\
 .br
  op monitor interval="60" role="Promoted" timeout="700" \\
 .br
- op monitor interval="61" role="Slave" timeout="700" \\
+ op monitor interval="61" role="Started" timeout="700" \\
 .br
  params SID="PRD" InstanceNumber="10" PREFER_SITE_TAKEOVER="false" \\
 .br

--- a/man/ocf_suse_SAPHanaController.7
+++ b/man/ocf_suse_SAPHanaController.7
@@ -436,9 +436,9 @@ nodeB: 1479202132
 * Set parameter AUTOMATED_REGISTER="true". See SUPPORTED PARAMETERS section above for details.
 
 .RS 4
-# crm_resource -r rsc_SAPHana_HA1_HDB00 -p AUTOMATED_REGISTER -v true
+# crm_resource -r rsc_SAPHanaCon_HA1_HDB00 -p AUTOMATED_REGISTER -v true
 .br
-# crm_resource -r rsc_SAPHana_HA1_HDB00 -g AUTOMATED_REGISTER
+# crm_resource -r rsc_SAPHanaCon_HA1_HDB00 -g AUTOMATED_REGISTER
 .RE
 .PP
 .\"

--- a/man/ocf_suse_SAPHanaController.7
+++ b/man/ocf_suse_SAPHanaController.7
@@ -227,7 +227,7 @@ Reports whether the HANA instance is running. Suggested minimum timeout: 60\&.
 Reports whether the HANA database seems to be working in multi-state mode. It also needs to check the system replication status. Suggested minimum timeout: 700\&. Suggested interval: 60\&.
 .RE
 .PP
-\fBmonitor (Slave role)\fR
+\fBmonitor (demoted role)\fR
 .RS 4
 Reports whether the HANA database seems to be working in multi-state mode. It also needs to check the system replication status. The secondary role's monitor interval has to be different from the primary (master) role. Suggested minimum timeout: 700\&. Suggested interval: 61\&.
 .RE
@@ -273,7 +273,7 @@ op demote interval="0" timeout="320" \\
 .br
 op monitor interval="60" role="Promoted" timeout="700" \\
 .br
-op monitor interval="61" role="Slave" timeout="700" \\
+op monitor interval="61" role="Started" timeout="700" \\
 .br
 params SID="SLE" InstanceNumber="00" PREFER_SITE_TAKEOVER="true" \\
 .br

--- a/man/ocf_suse_SAPHanaController.7
+++ b/man/ocf_suse_SAPHanaController.7
@@ -271,7 +271,7 @@ op promote interval="0" timeout="900" \\
 .br
 op demote interval="0" timeout="320" \\
 .br
-op monitor interval="60" role="Master" timeout="700" \\
+op monitor interval="60" role="Promoted" timeout="700" \\
 .br
 op monitor interval="61" role="Slave" timeout="700" \\
 .br

--- a/man/ocf_suse_SAPHanaTopology.7
+++ b/man/ocf_suse_SAPHanaTopology.7
@@ -206,7 +206,7 @@ notify="true" interleave="true" clone-node-max="1"
 .PP
 location SAPHanaTop_not_on_majority_maker cln_SAPHanaTop_HAE_HDB00 -inf: vm-majority
 .PP
-order SAPHanaTop_first Optional: cln_SAPHanaTop_SLE_HDB00 msl_SAPHC_SLE_HDB00
+order SAPHanaTop_first Optional: cln_SAPHanaTop_SLE_HDB00 mst_SAPHC_SLE_HDB00
 .RE
 .PP
 .\"

--- a/man/susCostOpt.py.7
+++ b/man/susCostOpt.py.7
@@ -167,7 +167,7 @@ The procedure at a glance:
 .RS 2
 1. set HANA multi-state resource into maintenance
 .br
-2. cleanup HANA primitive resource
+2. clean up HANA primitive resource
 .br
 3. site_A: register former primary as new secondary
 .br


### PR DESCRIPTION
man pages: examples changed from multi-state to promotable clone, typos fixed