### PR TITLE
preparation for next package update (phase II a)

### DIFF
--- a/SAPHanaSR-angi.changes
+++ b/SAPHanaSR-angi.changes
@@ -1,4 +1,23 @@
 -------------------------------------------------------------------
+Wed Jul  5 15:36:16 UTC 2023 - abriel@suse.com
+
+- Version bump to 1.001.5
+  * package is still in status 'technical preview'
+  * add support for SAPHana ScaleOut environments without standby
+    nodes
+  * starting to rewrite SAPHanaSR tools from bash to python.
+    SAPHanaSR-showAttr and SAPHanaSR-replay-archive
+    The name of the tools is not changed by this action, but there
+    are some improvements in functionality. See the man pages for
+    details.
+    The tools SAPHanaSR-monitor and SAPHanaSR-filter are deprecated.
+    The classic version of these tools is still shipped in the
+    package side-by-side to the rewritten and more powerful
+    tools in /usr/bin. Their name is suffixed by '-legacy'.
+    The classic version of the tools is deprecated and will be
+    removed in a later package update.
+
+-------------------------------------------------------------------
 Mon Apr 17 07:44:23 UTC 2023 - abriel@suse.com
 
 - New package name and new version 1.001.4


### PR DESCRIPTION
add changelog infos for the next planned package update.
specify the supported ScaleOut use cases
add deprecated information for the classic tools ('-legacy')