### PR TITLE
typo fixed to enable RemoveSAPSockets choice

### DIFF
--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -845,7 +845,7 @@ function saphana_init() {
     SAPVIRHOST=${vName}
     PreferSiteTakeover="$OCF_RESKEY_PREFER_SITE_TAKEOVER"
     AUTOMATED_REGISTER="${OCF_RESKEY_AUTOMATED_REGISTER:-false}"
-    RemoveSAPSockets="${CF_RESKEY_REMOVE_SAP_SOCKETS:-true}"
+    RemoveSAPSockets="${OCF_RESKEY_REMOVE_SAP_SOCKETS:-true}"
     LPA_DIRECTORY=/var/lib/SAPHanaRA
     LPA_ATTR=("lpa_${sid}_lpt" "forever")
     super_ocf_log debug "DBG: SID=$SID, sid=$sid, SIDInstanceName=$SIDInstanceName, InstanceName=$InstanceName, InstanceNr=$InstanceNr, SAPVIRHOST=$SAPVIRHOST"


### PR DESCRIPTION
This is just a minor typo fix, which I came across when testing the **RemoveSAPSockets** parameter and noticed it cannot be disabled.