### PR TITLE
bsc#1210728 - avoid explicid and implicid usage of /tmp filesystem 

### DIFF
--- a/SAPHanaSR.changes_12
+++ b/SAPHanaSR.changes_12
@@ -1,4 +1,20 @@
 -------------------------------------------------------------------
+Mon Aug 21 16:24:32 UTC 2023 - abriel@suse.com
+
+- Version bump to 0.162.2
+  * avoid explicid and implicid usage of /tmp filesystem to keep
+    the SAPHanaSR resource agents working even in situations with
+    /tmp filesystem full.
+    (bsc#1210728)
+  * update update man pages:
+    SAPHanaSR_basic_cluster.7
+    susCostOpt.py.7
+    SAPHanaSR_maintenance_examples.7
+    SAPHanaSR-monitor.8
+  * add improvements from SAP to the RA scripts, part II
+    (jsc#PED-1739, jsc#PED-2608)
+
+-------------------------------------------------------------------
 Tue Jan 24 15:27:27 UTC 2023 - abriel@suse.com
 
 - Version bump to 0.162.1

--- a/SAPHanaSR.changes_15
+++ b/SAPHanaSR.changes_15
@@ -1,4 +1,20 @@
 -------------------------------------------------------------------
+Mon Aug 21 16:24:32 UTC 2023 - abriel@suse.com
+
+- Version bump to 0.162.2
+  * avoid explicid and implicid usage of /tmp filesystem to keep
+    the SAPHanaSR resource agents working even in situations with
+    /tmp filesystem full.
+    (bsc#1210728)
+  * update update man pages:
+    SAPHanaSR_basic_cluster.7
+    susCostOpt.py.7
+    SAPHanaSR_maintenance_examples.7
+    SAPHanaSR-monitor.8
+  * add improvements from SAP to the RA scripts, part II
+    (jsc#PED-1739, jsc#PED-2608)
+
+-------------------------------------------------------------------
 Tue Jan 24 15:27:27 UTC 2023 - abriel@suse.com
 
 - Version bump to 0.162.1

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -1021,10 +1021,9 @@ function saphana_init() {
     # since rev 112.03 the old option is changed and we should use -sr_stateConfiguration where ever possible
     #
     hdbState="hdbnsutil -sr_stateConfiguration"
-    hdbMap="hdbnsutil -sr_stateHostMapping"
+    # DONE: PRIO1: Beginning from SAP HANA rev 112.03 -sr_state is not longer supported
     if version "$hdbver" "<" "1.00.111"; then
         hdbState="hdbnsutil -sr_state"
-        hdbMap="hdbnsutil -sr_state"
     fi
     super_ocf_log info "FLOW ${FUNCNAME[0]} rc=$OCF_SUCCESS"
     return $OCF_SUCCESS
@@ -1241,50 +1240,49 @@ function check_for_primary() {
     # DONE: PRIO2: Maybe we need to use a fallback interface when hdbnsutil does not answer properly -> lookup in config files?
     # TODO:        This might also solve some problems when we could not figure-out the local or remote site name (site_name,site_id from global.ini)
     local chkMethod=""
-    local ini_mode=""
+    local node_status=""
+    local node_full_status=""
     for chkMethod in  hU hU hU gP; do
-       case "$chkMethod" in
-           gP )
+        case "$chkMethod" in
+            gP )
                 # fallback for 'hdbnsutil' failing 3 times.
                 local gpKeys=""
                 gpKeys=$(echo --key=global.ini/system_replication/{actual_mode,mode})
                 node_full_status=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "python getParameter.py $gpKeys --sapcontrol=1" 2>&1 | awk -F/ 'BEGIN {out=0} /^SAPCONTROL-OK: <begin>/ { out=1 } /^SAPCONTROL-OK: <end>/ { out=0 } /=/ {if (out==1) {print $3} }')
                 # first try to get the value of 'actual_mode' from the global.ini
-                ini_mode=$(echo "$node_full_status" | awk -F= '$1=="actual_mode" {print $2}')
+                [[ "$node_full_status" =~ actual_mode=([^$'\n']+) ]] && node_status=${BASH_REMATCH[1]}
                 # if 'actual_mode' is not available, fallback to 'mode'
-                if [ -z "$ini_mode" ]; then
-                    ini_mode=$(echo "$node_full_status" | awk -F= '$1=="mode" {print $2}')
+                if [ -z "$node_status" ]; then
+                    [[ "$node_full_status" =~ mode=([^$'\n']+) ]] && node_status=${BASH_REMATCH[1]}
                 fi
-                node_status="$ini_mode"
                 super_ocf_log info "ACT: Using getParameter.py as fallback - node_status=$node_status"
                 ;;
-           hU | * )
-                # DONE: PRIO1: Beginning from SAP HANA rev 112.03 -sr_state is not longer supported
-                node_full_status=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "$hdbState" 2>/dev/null )
-                node_status=$(echo "$node_full_status" | awk '$1=="mode:" {print $2}')
+            hU | * )
+                node_full_status=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "$hdbState --sapcontrol=1" 2>/dev/null )
+                [[ "$node_full_status" =~ mode=([^$'\n']+) ]] && node_status=${BASH_REMATCH[1]}
                 super_ocf_log debug "DBG: check_for_primary: node_status=$node_status"
                 ;;
-       esac
-       case "$node_status" in
-           primary )
-               rc=$HANA_STATE_PRIMARY
-               break;;
-           syncmem | sync | async )
-               rc=$HANA_STATE_SECONDARY
-               break;;
-           none ) # have seen that mode on second side BEFEORE we registered it as replica
-               rc=$HANA_STATE_STANDALONE
-               break;;
-           * )
-               super_ocf_log err "ACT: check_for_primary:  we didn't expect node_status to be: <$node_status>"
-               dump=$( echo $node_status | hexdump -C );
-               super_ocf_log err "ACT: check_for_primary:  we didn't expect node_status to be: DUMP <$dump>"
-               # TODO: Limit the runtime of hdbnsutil and use getParameter.py as fallback
-               # SAP_CALL
-               super_ocf_log debug "DEC: check_for_primary: loop=$i: node_status=$node_status"
-               # TODO: PRIO1: Maybe we need to keep the old value for P/S/N, if hdbnsutil just crashes
-       esac;
-       sleep 2
+        esac
+        case "$node_status" in
+            primary )
+                rc=$HANA_STATE_PRIMARY
+                break;;
+            syncmem | sync | async )
+                rc=$HANA_STATE_SECONDARY
+                break;;
+            none ) # have seen that mode on second side BEFEORE we registered it as replica
+                rc=$HANA_STATE_STANDALONE
+                break;;
+            * )
+                super_ocf_log err "ACT: check_for_primary:  we didn't expect node_status to be: <$node_status>"
+                dump=$( echo $node_status | hexdump -C );
+                super_ocf_log err "ACT: check_for_primary:  we didn't expect node_status to be: DUMP <$dump>"
+                ((i++))
+                super_ocf_log debug "DEC: check_for_primary: loop=$i: node_status=$node_status"
+                # TODO: PRIO1: Maybe we need to keep the old value for P/S/N, if hdbnsutil just crashes
+                # lets pause a bit to give hdbnsutil a chance to answer next time
+                sleep 2
+        esac;
     done
     super_ocf_log info "FLOW ${FUNCNAME[0]} rc=$rc"
     return $rc

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -1261,7 +1261,7 @@ function check_for_primary() {
                 ;;
             hU | * )
                 node_full_status=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "$hdbState --sapcontrol=1" 2>/dev/null )
-                [[ "$node_full_status" =~ "SAPCONTROL-OK: <begin>".*"/mode="([^$'\n']*).*"SAPCONTROL-OK: <end>" ]] && node_status=${BASH_REMATCH[1]}
+                [[ "$node_full_status" =~ "SAPCONTROL-OK: <begin>".*(^|$'\n')"mode="([^$'\n']*).*"SAPCONTROL-OK: <end>" ]] && node_status=${BASH_REMATCH[2]}
                 super_ocf_log debug "DBG: check_for_primary: node_status=$node_status"
                 ;;
         esac

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -114,12 +114,11 @@ function saphana_usage() {
     local rc=0
     methods=$(saphana_methods)
     methods=$(echo $methods | tr ' ' '|')
-    cat <<-EOF
-    usage: $0 ($methods)
+    echo "    usage: $0 ($methods)
 
     $0 manages two SAP HANA databases (scale-up) in system replication.
 
-    The 'start'        operation starts the HANA instance or bring the "clone instance" to a WAITING status
+    The 'start'        operation starts the HANA instance or bring the \"clone instance\" to a WAITING status
     The 'stop'         operation stops the HANA instance
     The 'status'       operation reports whether the HANA instance is running
     The 'monitor'      operation reports whether the HANA instance seems to be working in multi-state it also needs to check the system replication status
@@ -129,8 +128,7 @@ function saphana_usage() {
     The 'validate-all' operation reports whether the parameters are valid
     The 'methods'      operation reports on the methods $0 supports
     The 'reload'       operation allows to adapt resource parameters
-
-EOF
+"
     return $rc
 }
 
@@ -151,11 +149,9 @@ function backup_global_and_nameserver() {
 function saphana_meta_data() {
     super_ocf_log info "FLOW ${FUNCNAME[0]} ($*)"
     local rc=0
-#
-    cat <<END
-<?xml version="1.0"?>
+    echo '<?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
-<resource-agent name="SAPHana" version="$SAPHanaVersion">
+<resource-agent name="SAPHana" version="'$SAPHanaVersion'">
 <version>1.0</version>
 
 <shortdesc lang="en">Manages two SAP HANA database systems in system replication (SR).</shortdesc>
@@ -192,7 +188,7 @@ The resource agent uses the following four interfaces provided by SAP:
    Interface is SQL query into HANA (system replication table).  The hdbsql query will be replaced by a python script
    "systemReplicationStatus.py" in SAP HANA SPS8 or 9.
    As long as we need to use hdbsql you need to set up secure store users for linux user root to be able to
-   access the SAP HANA database. You need to configure a secure store user key "SAPHANA${SID}SR" which can connect the SAP
+   access the SAP HANA database. You need to configure a secure store user key "SAPHANA'${SID}'SR" which can connect the SAP
    HANA database:
 
 5. saphostctrl
@@ -290,8 +286,7 @@ The resource agent uses the following four interfaces provided by SAP:
     <action name="methods" timeout="5" />
     <action name="reload" timeout="5" />
 </actions>
-</resource-agent>
-END
+</resource-agent>'
 super_ocf_log info "FLOW ${FUNCNAME[0]} rc=$rc"
 return $rc
 }
@@ -593,8 +588,10 @@ scoring_crm_master()
     local sync="$2"
     local myScore=''
     for scan in "${SCORING_TABLE[@]}"; do
-        read rolePatt syncPatt score <<< $scan
+        # $scan needs "" to prevent globbing, as the scoring tables include '.*'
+        read rolePatt syncPatt score < <(echo "$scan")
         if [[ "$roles" =~ $rolePatt ]] ; then
+            # $syncPatt must NOT have "" for correct matching
             if [[ "$sync" =~ $syncPatt ]] ; then
                 super_ocf_log info "DEC: scoring_crm_master: roles($roles) are matching pattern ($rolePatt)"
                 super_ocf_log info "DEC: scoring_crm_master: sync($sync) is matching syncPattern ($syncPatt)"
@@ -675,9 +672,9 @@ function HANA_CALL()
                   ;;
         *       )
                   errExt=$(date '+%s%N')_${sid}adm
-                  su_err_log=/tmp/HANA_CALL_SU_RA_${errExt}
-                  cmd_out_log=/tmp/HANA_CALL_CMD_RA_OUT_${errExt}
-                  cmd_err_log=/tmp/HANA_CALL_CMD_RA_${errExt}
+                  su_err_log=/run/HANA_CALL_SU_RA_${errExt}
+                  cmd_out_log=/run/HANA_CALL_CMD_RA_OUT_${errExt}
+                  cmd_err_log=/run/HANA_CALL_CMD_RA_${errExt}
 
                   output=$(timeout --foreground -s 9 "$timeOut" $pre_cmd "($pre_script; timeout -s 9 $timeOut $cmd > $cmd_out_log) >& $cmd_err_log" 2>"$su_err_log"); rc=$?
 
@@ -1673,8 +1670,8 @@ function saphana_start_primary()
             if ocf_is_true "${PreferSiteTakeover}"; then
                 remoteStatus="$remoteRole:$remoteSync"
                 case "$remoteStatus" in
-		    [234]:S:*:SOK | [234]:S:*:PRIM )
-		        lpa_advice="wait"
+                    [234]:S:*:SOK | [234]:S:*:PRIM )
+                        lpa_advice="wait"
                         # TODO: PRIO3: Split WAIT into WAIT4TAKEOVER
                         super_ocf_log info "DEC: saphana_primary - waiting for secondary to takeover (SOK, PreferSiteTakover)"
                     ;;
@@ -1835,7 +1832,7 @@ check_for_primary_master()
                 super_ocf_log debug "DBG: check_for_primary_master (3) ch_role=$ch_role"
                 awk -F: 'BEGIN { rc=1 }
                          $1 ~ "[34]" && $2 == "P" && $4 == "master" { rc=0 }
-                         END { exit rc }' <<< $ch_role  ; rc=$?
+                         END { exit rc }' < <(echo $ch_role) ; rc=$?
                 super_ocf_log debug "DBG: check_for_primary_master (4) rc=$rc"
             fi
         done
@@ -2056,7 +2053,7 @@ function lpa_pull_lpt() {
     local readrest=0
     local lpa_file="$LPA_DIRECTORY/lpa_${sid}_${NODENAME}"
     if [ -f $lpa_file ]; then
-        read lpt readrest <<<$(cat $lpa_file) # exactly load first word from file to lpt
+        read lpt readrest < <(cat $lpa_file) # exactly load first word from file to lpt
     fi
     if [ -n "$lpt" ]; then
         rc=0
@@ -2499,7 +2496,7 @@ function saphana_monitor_primary()
                 else
                     rc=$OCF_SUCCESS
                 fi
-	            set_SRHOOK_PRIM
+                set_SRHOOK_PRIM
                 my_role=$(get_hana_attribute "${NODENAME}" "${ATTR_NAME_HANA_ROLES[@]}")
                 super_ocf_log info "DEC: saphana_monitor_primary: scoring_crm_master($my_role,$my_sync)"
                 scoring_crm_master "$my_role" "$my_sync"
@@ -2729,15 +2726,15 @@ function saphana_monitor_clone() {
     my_sync=$(get_SRHOOK "$sr_name" "$NODENAME")
     set_hana_attribute "$NODENAME" "-" "${ATTR_NAME_HANA_SRACTION_HISTORY[@]}"
 
-	if ocf_is_probe; then
-		super_ocf_log debug "DBG: PROBE ONLY"
-	else
-		super_ocf_log debug "DBG: REGULAR MONITOR"
-	fi
-	#
-	# First check, if we are PRIMARY or SECONDARY
-	#
-	check_for_primary; primary_status=$?
+    if ocf_is_probe; then
+        super_ocf_log debug "DBG: PROBE ONLY"
+    else
+        super_ocf_log debug "DBG: REGULAR MONITOR"
+    fi
+    #
+    # First check, if we are PRIMARY or SECONDARY
+    #
+    check_for_primary; primary_status=$?
     if [ $primary_status -eq $HANA_STATE_PRIMARY ]; then
         # FIX: bsc#919925 Leaving Node Maintenance stops HANA Resource Agent
         # TODO: PRIO1: Maybe we need a lpa-check here to
@@ -2843,7 +2840,7 @@ function saphana_promote_clone() {
         fi
     fi
     if [ $rc -eq $OCF_SUCCESS ]; then
-	    set_SRHOOK_PRIM
+        set_SRHOOK_PRIM
     fi
     super_ocf_log info "FLOW ${FUNCNAME[0]} rc=$rc"
     return $rc

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -672,9 +672,9 @@ function HANA_CALL()
                   ;;
         *       )
                   errExt=$(date '+%s%N')_${sid}adm
-                  su_err_log=/run/HANA_CALL_SU_RA_${errExt}
-                  cmd_out_log=/run/HANA_CALL_CMD_RA_OUT_${errExt}
-                  cmd_err_log=/run/HANA_CALL_CMD_RA_${errExt}
+                  su_err_log=${SAPHanaSR_RUN}/HANA_CALL_SU_RA_${errExt}
+                  cmd_out_log=${SAPHanaSR_RUN}/HANA_CALL_CMD_RA_OUT_${errExt}
+                  cmd_err_log=${SAPHanaSR_RUN}/HANA_CALL_CMD_RA_${errExt}
 
                   output=$(timeout --foreground -s 9 "$timeOut" $pre_cmd "($pre_script; timeout -s 9 $timeOut $cmd > $cmd_out_log) >& $cmd_err_log" 2>"$su_err_log"); rc=$?
 
@@ -819,6 +819,10 @@ function saphana_init() {
     super_ocf_log debug "DBG: Used new method to get SID ($SID) and InstanceNr ($InstanceNr)"
     sid="${SID,,}"
     sidadm="${sid}adm"
+    # create subdirectory in /run
+    SAPHanaSR_RUN="/run/SAPHanaSR_${sid}"
+    mkdir -p $SAPHanaSR_RUN
+    chown $sidadm $SAPHanaSR_RUN
     # TODO PRIO3: Do we need a parameter for the RA to be able to adjust hdbSrQueryTimeout?
     hdbSrQueryTimeout=180
     # DONE: PRIO4: SAPVIRHOST might be different to NODENAME
@@ -1239,24 +1243,25 @@ function check_for_primary() {
     local chkMethod=""
     local node_status=""
     local node_full_status=""
+    local i=0
     for chkMethod in  hU hU hU gP; do
         case "$chkMethod" in
             gP )
                 # fallback for 'hdbnsutil' failing 3 times.
                 local gpKeys=""
                 gpKeys=$(echo --key=global.ini/system_replication/{actual_mode,mode})
-                node_full_status=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "python getParameter.py $gpKeys --sapcontrol=1" 2>&1 | awk -F/ 'BEGIN {out=0} /^SAPCONTROL-OK: <begin>/ { out=1 } /^SAPCONTROL-OK: <end>/ { out=0 } /=/ {if (out==1) {print $3} }')
+                node_full_status=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "python getParameter.py $gpKeys --sapcontrol=1" 2>&1)
                 # first try to get the value of 'actual_mode' from the global.ini
-                [[ "$node_full_status" =~ actual_mode=([^$'\n']+) ]] && node_status=${BASH_REMATCH[1]}
+                [[ "$node_full_status" =~ "SAPCONTROL-OK: <begin>".*"/actual_mode="([^$'\n']*).*"SAPCONTROL-OK: <end>" ]] && node_status=${BASH_REMATCH[1]}
                 # if 'actual_mode' is not available, fallback to 'mode'
                 if [ -z "$node_status" ]; then
-                    [[ "$node_full_status" =~ mode=([^$'\n']+) ]] && node_status=${BASH_REMATCH[1]}
+                    [[ "$node_full_status" =~ "SAPCONTROL-OK: <begin>".*"/mode="([^$'\n']*).*"SAPCONTROL-OK: <end>" ]] && node_status=${BASH_REMATCH[1]}
                 fi
                 super_ocf_log info "ACT: Using getParameter.py as fallback - node_status=$node_status"
                 ;;
             hU | * )
                 node_full_status=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "$hdbState --sapcontrol=1" 2>/dev/null )
-                [[ "$node_full_status" =~ mode=([^$'\n']+) ]] && node_status=${BASH_REMATCH[1]}
+                [[ "$node_full_status" =~ "SAPCONTROL-OK: <begin>".*"/mode="([^$'\n']*).*"SAPCONTROL-OK: <end>" ]] && node_status=${BASH_REMATCH[1]}
                 super_ocf_log debug "DBG: check_for_primary: node_status=$node_status"
                 ;;
         esac

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -2,7 +2,7 @@
 #
 # SAPHanaTopology
 #
-# Description:	Clone resource to analyze SAPHana-Topology
+# Description: Clone resource to analyze SAPHana-Topology
 #
 ###################################################################################################################
 #
@@ -22,7 +22,7 @@
 # OCF instance parameters:
 #   OCF_RESKEY_SID            (LNX, NDB, SLE)
 #   OCF_RESKEY_InstanceNumber (00..99)
-#	OCF_RESKEY_DIR_EXECUTABLE   (optional, well known directories will be searched by default)
+#   OCF_RESKEY_DIR_EXECUTABLE   (optional, well known directories will be searched by default)
 #   OCF_RESKEY_SAPHanaFilter    (outdated, replaced by cluster property hana_${sid}_glob_filter)
 #
 #######################################################################
@@ -96,12 +96,11 @@ function sht_usage() {
     local rc=0
     methods=$(sht_methods)
     methods=$(echo $methods | tr ' ' '|')
-  cat <<-!
-	usage: $0 ($methods)
+    echo "usage: $0 ($methods)
 
     $0 manages a SAP HANA Instance as an HA resource.
 
-    The 'start'        operation starts the HANA instance or bring the "instance" to a WAITING (for primary) status
+    The 'start'        operation starts the HANA instance or bring the \"instance\" to a WAITING (for primary) status
     The 'stop'         operation stops the HANA instance
     The 'status'       operation reports whether the HANA instance is running
     The 'monitor'      operation reports whether the HANA instance seems to be working in multi-state it also needs to check the system replication status
@@ -109,9 +108,8 @@ function sht_usage() {
     The 'validate-all' operation reports whether the parameters are valid
     The 'methods'      operation reports on the methods $0 supports
     The 'reload'       operation allows to change parameters like HANA_CALL_TIMEOUT without forcing a recover of all instances
-
-	!
-	return $rc
+"
+    return $rc
 }
 
 #
@@ -122,10 +120,9 @@ function sht_usage() {
 function sht_meta_data() {
     super_ocf_log info "FLOW ${FUNCNAME[0]} ($*)"
     local rc=0
-	cat <<END
-<?xml version="1.0"?>
+    echo '<?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
-<resource-agent name="SAPHanaTopology" version="$SAPHanaTopologyVersion">
+<resource-agent name="SAPHanaTopology" version="'$SAPHanaTopologyVersion'">
     <version>1.0</version>
     <shortdesc lang="en">Analyzes SAP HANA System Replication Topology.</shortdesc>
     <longdesc lang="en">This RA analyzes the SAP HANA topology and "sends" all findings via the node status attributes to
@@ -174,8 +171,8 @@ SAPHanaTopology scans the output table of landscapeHostConfiguration.py to ident
         <content type="string" default="60" />
     </parameter>
     <parameter name="DIR_EXECUTABLE" unique="0" required="0">
-        <longdesc lang="en">Path to the SAP Hana Instance executable directory. If not set the RA tries /usr/sap/\$SID/\$InstanceName/exe.
-        While InstanceName is the string of "HDB" and \$InstanceNumber for SAP Hana databases.
+        <longdesc lang="en">Path to the SAP Hana Instance executable directory. If not set the RA tries /usr/sap/$SID/$InstanceName/exe.
+        While InstanceName is the string of "HDB" and $InstanceNumber for SAP Hana databases.
         </longdesc>
         <shortdesc lang="en">Path to the SAP Hana Instance executable directory.</shortdesc>
         <content type="string" default="" />
@@ -196,10 +193,9 @@ SAPHanaTopology scans the output table of landscapeHostConfiguration.py to ident
     <action name="methods" timeout="5" />
     <action name="reload" timeout="5" />
 </actions>
-</resource-agent>
-END
-super_ocf_log info "FLOW ${FUNCNAME[0]} rc=$rc"
-return $rc
+</resource-agent>'
+    super_ocf_log info "FLOW ${FUNCNAME[0]} rc=$rc"
+    return $rc
 }
 
 #
@@ -276,22 +272,21 @@ function set_hana_attribute()
 # methods: What methods/operations do we support?
 #
 function sht_methods() {
-  super_ocf_log info "FLOW ${FUNCNAME[0]} ($*)"
-  local rc=0
-  cat <<-!
-    start
-    stop
-    status
-    monitor
-    notify
-    validate-all
-    methods
-    meta-data
-    usage
-    admin-setup
-    reload
-	!
-	return $rc
+    super_ocf_log info "FLOW ${FUNCNAME[0]} ($*)"
+    local rc=0
+    echo "
+      start
+      stop
+      status
+      monitor
+      notify
+      validate-all
+      methods
+      meta-data
+      usage
+      admin-setup
+      reload"
+    return $rc
 }
 
 #
@@ -422,9 +417,9 @@ function HANA_CALL()
                   ;;
         *       )
                   errExt=$(date '+%s%N')_${sid}adm
-                  su_err_log=/tmp/HANA_CALL_SU_TOP_${errExt}
-                  cmd_out_log=/tmp/HANA_CALL_CMD_TOP_OUT_${errExt}
-                  cmd_err_log=/tmp/HANA_CALL_CMD_TOP_${errExt}
+                  su_err_log=/run/HANA_CALL_SU_TOP_${errExt}
+                  cmd_out_log=/run/HANA_CALL_CMD_TOP_OUT_${errExt}
+                  cmd_err_log=/run/HANA_CALL_CMD_TOP_${errExt}
 
                   output=$(timeout "$timeOut" $pre_cmd "($pre_script; $cmd > $cmd_out_log) >& $cmd_err_log" 2>"$su_err_log"); rc=$?
 
@@ -991,7 +986,7 @@ function sht_stop_clone() {
     sht_stop; rc=$? # till now it returns everytime $OCF_SUCCESS
     if [ "$tout" -eq 1 ]; then
         # timeout of landscapeHostConfiguration.py - let stop fail
-	rc=$OCF_ERR_GENERIC
+        rc=$OCF_ERR_GENERIC
     fi
 
     super_ocf_log info "FLOW ${FUNCNAME[0]} rc=$rc"
@@ -1007,13 +1002,13 @@ function sht_stop_clone() {
 function sht_monitor_clone() {
     super_ocf_log info "FLOW ${FUNCNAME[0]} ($*)"
     #
-	local rc=$OCF_ERR_GENERIC
-	local promoted=0
+    local rc=$OCF_ERR_GENERIC
+    local promoted=0
     local init_attribute=0
 
 
-	if ocf_is_probe; then
-		super_ocf_log debug "DBG: PROBE ONLY"
+    if ocf_is_probe; then
+        super_ocf_log debug "DBG: PROBE ONLY"
         sht_monitor; rc=$?
         local hana_version
         hana_version=$(grep -s -m1 -oP 'fullversion: \K.+(?= Build)' "/usr/sap/$SID/$InstanceName/exe/manifest")
@@ -1022,18 +1017,18 @@ function sht_monitor_clone() {
         if [[ -n $hana_version ]]; then
             set_hana_attribute "${NODENAME}" "$hana_version" ${ATTR_NAME_HANA_VERSION[@]}
         fi
-	else
-		super_ocf_log debug "DBG: REGULAR MONITOR"
+    else
+        super_ocf_log debug "DBG: REGULAR MONITOR"
         if ! check_saphostagent; then
              start_saphostagent
         fi
-	#
-	# First check, if we are PRIMARY or SECONDARY
-	#
-    super_ocf_log debug "DBG: HANA SID $SID"
-    super_ocf_log debug "DBG: HANA InstanceName $InstanceName"
-    super_ocf_log debug "DBG: HANA InstanceNr $InstanceNr"
-	check_for_primary; primary_status=$?
+        #
+        # First check, if we are PRIMARY or SECONDARY
+        #
+        super_ocf_log debug "DBG: HANA SID $SID"
+        super_ocf_log debug "DBG: HANA InstanceName $InstanceName"
+        super_ocf_log debug "DBG: HANA InstanceNr $InstanceNr"
+        check_for_primary; primary_status=$?
     if [ $primary_status -eq $HANA_STATE_PRIMARY ]; then
         hanaPrim="P"
         super_ocf_log debug "DBG: HANA IS PRIMARY"

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -475,8 +475,7 @@ function sht_init() {
     local myInstanceName=""
     local rc=$OCF_SUCCESS
     local hdbANSWER=""
-    local siteID
-    local siteNAME
+    local site=""
     local chkMethod=""
     SYSTEMCTL="/usr/bin/systemctl"
     systemd_unit_name="saphostagent.service"
@@ -562,11 +561,10 @@ function sht_init() {
     # since rev 112.03 the old option is changed and we should use -sr_stateConfiguration where ever possible
     #
     hdbState="hdbnsutil -sr_stateConfiguration"
-    hdbMap="hdbnsutil -sr_stateHostMapping"
     if version "$hdbver" "<" "1.00.111"; then
         hdbState="hdbnsutil -sr_state"
-        hdbMap="hdbnsutil -sr_state"
     fi
+    srmode=""
     #### SAP-CALL
     # hdbnsutil was a bit unstable in some tests so we recall the tool, if it fails to report the srmode
     for chkMethod in  hU hU hU gP ; do
@@ -576,21 +574,21 @@ function sht_init() {
         #super_ocf_log debug "DBG2: hdbANSWER=$hdbANSWER"
         #srmode=$(echo "$hdbANSWER" | awk -F= '/mode/ {print $2}')
         case "$chkMethod" in
-            gP ) # call getParameter (gP)
+            gP ) # call getParameter (gP) - fallback for 'hdbnsutil' failing 3 times.
                 local gpKeys=""
                 gpKeys=$(echo --key=global.ini/system_replication/{actual_mode,mode,site_name,site_id})
                 hdbANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "python getParameter.py $gpKeys --sapcontrol=1" 2>&1 | awk -F/ 'BEGIN {out=0} /^SAPCONTROL-OK: <begin>/ { out=1 } /^SAPCONTROL-OK: <end>/ { out=0 } /=/ {if (out==1) {print $3} }')
-                srmode=$(echo "$hdbANSWER" | awk -F= '$1=="actual_mode" {print $2}')
+                [[ "$hdbANSWER" =~ actual_mode=([^$'\n']+) ]] && srmode=${BASH_REMATCH[1]}
                 # if 'actual_mode' is not available, fallback to 'mode'
                 if [ -z "$srmode" ]; then
-                    srmode=$(echo "$hdbANSWER" | awk -F= '$1=="mode" {print $2}')
+                    [[ "$hdbANSWER" =~ mode=([^$'\n']+) ]] && srmode=${BASH_REMATCH[1]}
                 fi
                 super_ocf_log info "ACT: hdbnsutil not answering - using global.ini as fallback - srmode=$srmode"
                 ;;
             hU | * ) # call hdbnsUtil (hU) ( also for unknown chkMethod )
                 # DONE: PRIO1: Beginning from SAP HANA rev 112.03 -sr_state is not longer supported
                 hdbANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "$hdbState --sapcontrol=1" 2>/dev/null)
-                srmode=$(echo "$hdbANSWER" | awk -F= '$1=="mode" {print $2}')
+                [[ "$hdbANSWER" =~ mode=([^$'\n']+) ]] && srmode=${BASH_REMATCH[1]}
                 ;;
         esac
         case "$srmode" in
@@ -605,23 +603,22 @@ function sht_init() {
         esac
     done
     # TODO PRIO3: Implement a file lookup, if we did not get a result
-    siteID=$(echo "$hdbANSWER" | awk -F= '/site.id/ {print $2}')       # allow 'site_id' AND 'site id'
-    siteNAME=$(echo "$hdbANSWER" | awk -F= '/site.name/ {print $2}')
-    site=$siteNAME
+    [[ "$hdbANSWER" =~ site.name=([^$'\n']+) ]] && site=${BASH_REMATCH[1]}
     if [ -z "$srmode" ]; then
-        srmode=$(echo "$hdbANSWER" | awk -F= '$1=="actual_mode" {print $2}')
+        [[ "$hdbANSWER" =~ actual_mode=([^$'\n']+) ]] && srmode=${BASH_REMATCH[1]}
         # if 'actual_mode' is not available, fallback to 'mode'
         if [ -z "$srmode" ]; then
-            srmode=$(echo "$hdbANSWER" | awk -F= '$1=="mode" {print $2}')
+            [[ "$hdbANSWER" =~ mode=([^$'\n']+) ]] && srmode=${BASH_REMATCH[1]}
         fi
     fi
     #
     # for rev >= 111 we use the new mapping query
     #
     if version "$hdbver" ">=" "1.00.111"; then
+        hdbMap="hdbnsutil -sr_stateHostMapping"
         hdbANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "$hdbMap --sapcontrol=1" 2>/dev/null)
     fi
-    MAPPING=$(echo "$hdbANSWER" | awk -F[=/] '$1 == "mapping" && $3 != site { print $4 }' site=$site)
+    MAPPING=$(echo "$hdbANSWER" | awk -F[=/] '$1 == "mapping" && $3 != site { print $4 }' site="$site")
     super_ocf_log debug "DBG: site=$site, mode=$srmode, MAPPING=$MAPPING"
     if [ -n "$MAPPING" ]; then
         # we have a mapping from HANA, lets use it

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -587,7 +587,7 @@ function sht_init() {
             hU | * ) # call hdbnsUtil (hU) ( also for unknown chkMethod )
                 # DONE: PRIO1: Beginning from SAP HANA rev 112.03 -sr_state is not longer supported
                 hdbANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "$hdbState --sapcontrol=1" 2>/dev/null)
-                [[ "$hdbANSWER" =~ "SAPCONTROL-OK: <begin>".*"/mode="([^$'\n']*).*"SAPCONTROL-OK: <end>" ]] && srmode=${BASH_REMATCH[1]}
+                [[ "$hdbANSWER" =~ "SAPCONTROL-OK: <begin>".*(^|$'\n')"mode="([^$'\n']*).*"SAPCONTROL-OK: <end>" ]] && srmode=${BASH_REMATCH[2]}
                 ;;
         esac
         case "$srmode" in
@@ -602,12 +602,15 @@ function sht_init() {
         esac
     done
     # TODO PRIO3: Implement a file lookup, if we did not get a result
-    [[ "$hdbANSWER" =~ "SAPCONTROL-OK: <begin>".*"/site_name="([^$'\n']*).*"SAPCONTROL-OK: <end>" ]] && site=${BASH_REMATCH[1]}
+    # following pattern matching needs to work the output of getParameter.py and
+    # hdbnsutil as we do not know which of these commands succeeded in the loop
+    # above.
+    [[ "$hdbANSWER" =~ "SAPCONTROL-OK: <begin>".*/?"site"."name="([^$'\n']*).*"SAPCONTROL-OK: <end>" ]] && site=${BASH_REMATCH[1]}
     if [ -z "$srmode" ]; then
-        [[ "$hdbANSWER" =~ "SAPCONTROL-OK: <begin>".*"/actual_mode="([^$'\n']*).*"SAPCONTROL-OK: <end>" ]] && srmode=${BASH_REMATCH[1]}
+        [[ "$hdbANSWER" =~ "SAPCONTROL-OK: <begin>".*/?"actual"."mode="([^$'\n']*).*"SAPCONTROL-OK: <end>" ]] && srmode=${BASH_REMATCH[1]}
         # if 'actual_mode' is not available, fallback to 'mode'
         if [ -z "$srmode" ]; then
-            [[ "$hdbANSWER" =~ "SAPCONTROL-OK: <begin>".*"/mode="([^$'\n']*).*"SAPCONTROL-OK: <end>" ]] && srmode=${BASH_REMATCH[1]}
+            [[ "$hdbANSWER" =~ "SAPCONTROL-OK: <begin>".*/?"mode="([^$'\n']*).*"SAPCONTROL-OK: <end>" ]] && srmode=${BASH_REMATCH[1]}
         fi
     fi
     #

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -417,9 +417,9 @@ function HANA_CALL()
                   ;;
         *       )
                   errExt=$(date '+%s%N')_${sid}adm
-                  su_err_log=/run/HANA_CALL_SU_TOP_${errExt}
-                  cmd_out_log=/run/HANA_CALL_CMD_TOP_OUT_${errExt}
-                  cmd_err_log=/run/HANA_CALL_CMD_TOP_${errExt}
+                  su_err_log=${SAPHanaSR_RUN}/HANA_CALL_SU_TOP_${errExt}
+                  cmd_out_log=${SAPHanaSR_RUN}/HANA_CALL_CMD_TOP_OUT_${errExt}
+                  cmd_err_log=${SAPHanaSR_RUN}/HANA_CALL_CMD_TOP_${errExt}
 
                   output=$(timeout "$timeOut" $pre_cmd "($pre_script; $cmd > $cmd_out_log) >& $cmd_err_log" 2>"$su_err_log"); rc=$?
 
@@ -489,6 +489,10 @@ function sht_init() {
     super_ocf_log debug "DBG2: Used new method to get SID ($SID) and InstanceNr ($InstanceNr)"
     sid="${SID,,}"
     sidadm="${sid}adm"
+    # create subdirectory in /run
+    SAPHanaSR_RUN="/run/SAPHanaSR_${sid}"
+    mkdir -p $SAPHanaSR_RUN
+    chown $sidadm $SAPHanaSR_RUN
     ocf_env=$(env | grep 'OCF_RESKEY_CRM')
     super_ocf_log debug "DBG3: OCF: $ocf_env"
     ATTR_NAME_HANA_SYNC_STATUS=("hana_${sid}_sync_state" "reboot")  # SOK, SFAIL, UNKNOWN?
@@ -572,18 +576,18 @@ function sht_init() {
             gP ) # call getParameter (gP) - fallback for 'hdbnsutil' failing 3 times.
                 local gpKeys=""
                 gpKeys=$(echo --key=global.ini/system_replication/{actual_mode,mode,site_name,site_id})
-                hdbANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "python getParameter.py $gpKeys --sapcontrol=1" 2>&1 | awk -F/ 'BEGIN {out=0} /^SAPCONTROL-OK: <begin>/ { out=1 } /^SAPCONTROL-OK: <end>/ { out=0 } /=/ {if (out==1) {print $3} }')
-                [[ "$hdbANSWER" =~ actual_mode=([^$'\n']+) ]] && srmode=${BASH_REMATCH[1]}
+                hdbANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "python getParameter.py $gpKeys --sapcontrol=1" 2>&1)
+                [[ "$hdbANSWER" =~ "SAPCONTROL-OK: <begin>".*"/actual_mode="([^$'\n']*).*"SAPCONTROL-OK: <end>" ]] && srmode=${BASH_REMATCH[1]}
                 # if 'actual_mode' is not available, fallback to 'mode'
                 if [ -z "$srmode" ]; then
-                    [[ "$hdbANSWER" =~ mode=([^$'\n']+) ]] && srmode=${BASH_REMATCH[1]}
+                    [[ "$hdbANSWER" =~ "SAPCONTROL-OK: <begin>".*"/mode="([^$'\n']*).*"SAPCONTROL-OK: <end>" ]] && srmode=${BASH_REMATCH[1]}
                 fi
                 super_ocf_log info "ACT: hdbnsutil not answering - using global.ini as fallback - srmode=$srmode"
                 ;;
             hU | * ) # call hdbnsUtil (hU) ( also for unknown chkMethod )
                 # DONE: PRIO1: Beginning from SAP HANA rev 112.03 -sr_state is not longer supported
                 hdbANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "$hdbState --sapcontrol=1" 2>/dev/null)
-                [[ "$hdbANSWER" =~ mode=([^$'\n']+) ]] && srmode=${BASH_REMATCH[1]}
+                [[ "$hdbANSWER" =~ "SAPCONTROL-OK: <begin>".*"/mode="([^$'\n']*).*"SAPCONTROL-OK: <end>" ]] && srmode=${BASH_REMATCH[1]}
                 ;;
         esac
         case "$srmode" in
@@ -598,12 +602,12 @@ function sht_init() {
         esac
     done
     # TODO PRIO3: Implement a file lookup, if we did not get a result
-    [[ "$hdbANSWER" =~ site.name=([^$'\n']+) ]] && site=${BASH_REMATCH[1]}
+    [[ "$hdbANSWER" =~ "SAPCONTROL-OK: <begin>".*"/site_name="([^$'\n']*).*"SAPCONTROL-OK: <end>" ]] && site=${BASH_REMATCH[1]}
     if [ -z "$srmode" ]; then
-        [[ "$hdbANSWER" =~ actual_mode=([^$'\n']+) ]] && srmode=${BASH_REMATCH[1]}
+        [[ "$hdbANSWER" =~ "SAPCONTROL-OK: <begin>".*"/actual_mode="([^$'\n']*).*"SAPCONTROL-OK: <end>" ]] && srmode=${BASH_REMATCH[1]}
         # if 'actual_mode' is not available, fallback to 'mode'
         if [ -z "$srmode" ]; then
-            [[ "$hdbANSWER" =~ mode=([^$'\n']+) ]] && srmode=${BASH_REMATCH[1]}
+            [[ "$hdbANSWER" =~ "SAPCONTROL-OK: <begin>".*"/mode="([^$'\n']*).*"SAPCONTROL-OK: <end>" ]] && srmode=${BASH_REMATCH[1]}
         fi
     fi
     #


### PR DESCRIPTION
To keep the SAPHanaSR resource agents working even in situations with /tmp filesystem full avoid explicid and implicid usage of /tmp filesystem
Additional added the changes from Peter Pitterling (PR#158 and PR#159) with the changes discussed in the related PRs.
And fixing indentation by exchanging tabs with blanks