### PR TITLE
 HANA_CALL - reach in current shell PID - will be visible in HANA trace files

### DIFF
--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -641,7 +641,7 @@ function HANA_CALL()
     local use_su=1 # Default to be changed later (see TODO above)
     local pre_cmd=""
     local cmd=""
-    local pre_script=""
+    local pre_script=''
     local output=""
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -655,7 +655,7 @@ function HANA_CALL()
 
     if [ $use_su -eq 1 ]; then
         pre_cmd="su - ${sid}adm -c"
-        [[ $cmd == python* ]] && pre_script="cd $DIR_EXECUTABLE/python_support" || pre_script='true'
+        [[ $cmd == python* ]] && pre_script=": [$$]; cd $DIR_EXECUTABLE/python_support" || pre_script=": [$$]"
     else
         # as root user we need the library path to the SAP kernel to be able to call sapcontrol
         # check, if we already added DIR_EXECUTABLE at the beginning of LD_LIBRARY_PATH

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -386,7 +386,7 @@ function HANA_CALL()
     local use_su=1 # Default to be changed later (see TODO above)
     local pre_cmd=""
     local cmd=""
-    local pre_script=""
+    local pre_script=''
     local output=""
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -400,7 +400,7 @@ function HANA_CALL()
 
     if [ $use_su -eq 1 ]; then
         pre_cmd="su - ${sid}adm -c"
-        [[ $cmd == python* ]] && pre_script="cd $DIR_EXECUTABLE/python_support" || pre_script='true'
+        [[ $cmd == python* ]] && pre_script=": [$$]; cd $DIR_EXECUTABLE/python_support" || pre_script=": [$$]"
     else
         # as root user we need the library path to the SAP kernel to be able to call sapcontrol
         # check, if we already added DIR_EXECUTABLE at the beginning of LD_LIBRARY_PATH


### PR DESCRIPTION
improve supportability by providing the current shell PID, which is logged in the RA outputs, to HANA tracefiles. This allows mapping of the RA invocations and HANA executions which might have a delay in between.