### PR TITLE
RA runtime - bash SECONDS

### DIFF
--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -2951,7 +2951,7 @@ else
 fi
 
 # What kind of method was invoked?
-super_ocf_log info "RA ==== begin action $ACTION$CLACT ($SAPHanaVersion) ===="
+super_ocf_log info "RA ==== begin action $ACTION$CLACT ($SAPHanaVersion) (${SECONDS}s)===="
 ra_rc=$OCF_ERR_UNIMPLEMENTED
 case "$ACTION" in
     start|stop|monitor|promote|demote) # Standard controlling actions

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -44,8 +44,6 @@
 SAPHanaVersion="0.162.1"
 #
 # Initialization:
-timeB=${SECONDS}
-
 : ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}
 . ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
 
@@ -2976,9 +2974,7 @@ case "$ACTION" in
         ra_rc=$OCF_ERR_UNIMPLEMENTED
         ;;
 esac
-timeE=${SECONDS}
-(( timeR = timeE - timeB ))
 super_ocf_log debug "DBG: ==== SAPHanaFilter=$SAPHanaFilter"
-super_ocf_log info "RA ==== end action $ACTION$CLACT with rc=${ra_rc} ($SAPHanaVersion) (${timeR}s)===="
+super_ocf_log info "RA ==== end action $ACTION$CLACT with rc=${ra_rc} ($SAPHanaVersion) (${SECONDS}s)===="
 exit ${ra_rc}
 # set ts=4 sw=4 sts=4 et

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -1234,7 +1234,7 @@ else
     fi
 fi
 
-super_ocf_log info "RA ==== begin action $ACTION$CLACT ($SAPHanaTopologyVersion) ===="
+super_ocf_log info "RA ==== begin action $ACTION$CLACT ($SAPHanaTopologyVersion) (${SECONDS}s)===="
 ra_rc=$OCF_ERR_UNIMPLEMENTED
 case "$ACTION" in
     start|stop|monitor) # Standard controlling actions

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -30,8 +30,6 @@
 SAPHanaTopologyVersion="0.162.1"
 #
 # Initialization:
-timeB=${SECONDS}
-
 : ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}
 . ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
 
@@ -1255,7 +1253,5 @@ case "$ACTION" in
         ra_rc=$OCF_ERR_UNIMPLEMENTED
         ;;
 esac
-timeE=${SECONDS}
-(( timeR = timeE - timeB ))
-super_ocf_log info "RA ==== end action $ACTION$CLACT with rc=${ra_rc} ($SAPHanaTopologyVersion) (${timeR}s)===="
+super_ocf_log info "RA ==== end action $ACTION$CLACT with rc=${ra_rc} ($SAPHanaTopologyVersion) (${SECONDS}s)===="
 exit ${ra_rc}


### PR DESCRIPTION
- Runtime - remove timeE-timeB calculation as bash SECONDS is already passed time, remove variables
- add runtime also to 'begin action' (as this is not really the beginning) - most time is spent within initialization of RA
