### PR TITLE
bsc1216484: test/SAPHanaSR-hookHelper 

### DIFF
--- a/test/SAPHanaSR-hookHelper
+++ b/test/SAPHanaSR-hookHelper
@@ -195,7 +195,7 @@ case "$USECASE" in
     # query CIB and write content to a temporary file to limit the
     # cluster calls to a minimum.
     cibtmp=$(mktemp /tmp/SAPHanaSR_SRHhelper.XXXXXX)
-    cibadmin -Q > "$cibtmp"; rc=$?
+    /usr/sbin/cibadmin -Q > "$cibtmp"; rc=$?
     if [ "$rc" != 0 ]; then
         case "$rc" in
         102)


### PR DESCRIPTION
- use full path for cibadmin to  also support non root users in special user environments
- in the given bsc1216484  the root user was not setting /usr/sbin to the users PATH variable when using sudo