### PR TITLE
man SAPHanaSR.py.7: python 3

### DIFF
--- a/man/SAPHanaSR.py.7
+++ b/man/SAPHanaSR.py.7
@@ -1,6 +1,6 @@
-.\" Version: 0.160.1
+.\" Version: 0.162.0
 .\"
-.TH SAPHanaSR.py 7 "04 Jan 2024" "" "SAPHanaSR"
+.TH SAPHanaSR.py 7 "23 Jan 2024" "" "SAPHanaSR"
 .\"
 .SH NAME
 SAPHanaSR.py \- Provider for SAP HANA srHook method srConnectionChanged().
@@ -276,11 +276,11 @@ the internal cache for srHook status changes while Linux cluster is down, file i
 .PP
 .\"
 .SH REQUIREMENTS
-1. SAP HANA 2.0 SPS04 or later provides the HA/DR provider hook method
-srConnectionChanged() with multi-target aware parameters.
+1. SAP HANA 2.0 SPS05 rev.059 or later provides Python 3 as well as the HA/DR
+provider hook method srConnectionChanged() with multi-target aware parameters. 
 SAP HANA 1.0 does not provide them.
-The multi-target aware parameters are needed for the SAPHanaSR scale-up
-package.
+The Python 3 and multi-target aware parameters are needed for the SAPHanaSR
+scale-up package.
 .PP
 2. No other HADR provider hook script should be configured for the
 srConnectionChanged() method. Hook scripts for other methods, provided in


### PR DESCRIPTION
Hi,
updated the man page´s requirements to python 3, triggered by bug #1219071.
Might go into one of the next maintenance updates.
Regards,
Lars