### PR TITLE
bsc#1219194 - variable 'site' must be a global

### DIFF
--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -468,7 +468,6 @@ function sht_init() {
     local myInstanceName=""
     local rc=$OCF_SUCCESS
     local hdbANSWER=""
-    local site=""
     local chkMethod=""
     SYSTEMCTL="/usr/bin/systemctl"
     systemd_unit_name="saphostagent.service"
@@ -478,6 +477,9 @@ function sht_init() {
     SAPHOSTCTRL_PATH=${USRSAP}/hostctrl/exe
     HOSTEXEC_PATH=${SAPHOSTCTRL_PATH}/${HOSTEXECNAME}
     HOSTEXEC_PROFILE_PATH=${SAPHOSTCTRL_PATH}/host_profile
+    # site must be global as value from init function is used in
+    # function sht_monitor_clone to set the attribute
+    site=""
     NODENAME=$(crm_node -n)
     SID=$OCF_RESKEY_SID
     InstanceNr=$OCF_RESKEY_InstanceNumber


### PR DESCRIPTION
variable 'site' must be a global variable as the value found in the 'init' function will be used in 'sht_monitor_clone' to set the attribute in the CIB (bsc#1219194)