### PR TITLE
catch monitor calls for non-cloned resources

### DIFF
--- a/SAPHanaSR.changes_12
+++ b/SAPHanaSR.changes_12
@@ -1,13 +1,20 @@
 -------------------------------------------------------------------
-Wed Jan 19 18:10:10 UTC 2024 - abriel@suse.com
+Wed Jan 29 14:24:15 UTC 2024 - abriel@suse.com
 
 - Version bump to 0.162.3
   * Fix the hexdump log for empty node states
+  * catch monitor calls for non-cloned resources and report them as
+    unsupported instead of 'command not found'
+    (bsc#1218333)
+  * fix scope of variable 'site' to be global
+    (bsc#1219194)
   * susChkSrv.py - relocate function logTimestamp()
   * update man pages:
     SAPHanaSR.7
     ocf_suse_SAPHana.7
+    SAPHanaSR_maintenance_examples.7
     SAPHanaSR.py.7
+    SAPHanaSR-showAttr.8
 
 -------------------------------------------------------------------
 Thu Nov  2 17:50:47 UTC 2023 - abriel@suse.com

--- a/SAPHanaSR.changes_15
+++ b/SAPHanaSR.changes_15
@@ -1,13 +1,20 @@
 -------------------------------------------------------------------
-Wed Jan 19 18:11:10 UTC 2024 - abriel@suse.com
+Wed Jan 29 14:31:20 UTC 2024 - abriel@suse.com
   
 - Version bump to 0.162.3
   * Fix the hexdump log for empty node states
+  * catch monitor calls for non-cloned resources and report them as
+    unsupported instead of 'command not found'
+    (bsc#1218333)
+  * fix scope of variable 'site' to be global
+    (bsc#1219194)
   * susChkSrv.py - relocate function logTimestamp()
   * update man pages:
     SAPHanaSR.7
     ocf_suse_SAPHana.7
+    SAPHanaSR_maintenance_examples.7
     SAPHanaSR.py.7
+    SAPHanaSR-showAttr.8
 
 -------------------------------------------------------------------
 Thu Nov  2 17:49:47 UTC 2023 - abriel@suse.com

--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -2777,6 +2777,22 @@ function saphana_monitor_clone() {
 }
 
 #
+# function: saphana_monitor
+# this function should never be called currently.
+# it is intended for future releases which might support un-cloned resources
+# for now it is only used to print a reasonable error message in case of
+# non-cloned resources instead of 'command not found'
+#
+function saphana_monitor() {
+    if ! is_clone; then
+        super_ocf_log error "RA: resource is not defined as clone. This is not supported (OCF_ERR_UNIMPLEMENTED)"
+        return "$OCF_ERR_UNIMPLEMENTED"
+    else
+        return "$OCF_SUCCESS"
+    fi
+}
+
+#
 # function: saphana_promote_clone - promote a hana clone
 # params:   -
 # globals:  OCF_*(r), NODENAME(r), HANA_STATE_*, SID(r), InstanceName(r),

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -1005,6 +1005,22 @@ function sht_stop_clone() {
 }
 
 #
+# function: sht_monitor
+# this function should never be called currently.
+# it is intended for future releases which might support un-cloned resources
+# for now it is only used to print a reasonable error message in case of
+# non-cloned resources instead of 'command not found'
+#
+function sht_monitor() {
+    if ! is_clone; then
+        super_ocf_log error "RA: resource is not defined as clone. This is not supported (OCF_ERR_UNIMPLEMENTED)"
+        return "$OCF_ERR_UNIMPLEMENTED"
+    else
+        return "$OCF_SUCCESS"
+    fi
+}
+
+#
 # function: sht_monitor_clone - monitor a hana clone instance
 # params:   -
 # globals:  OCF_*, SID, InstanceNr, InstanceName, MAPPING(r)


### PR DESCRIPTION
 catch monitor calls for non-cloned resources and report them as unsupported instead of 'command not found' (bsc#1218333)
update changelog files