### PR TITLE
 SAPHanaSR_basic_cluster.7: fixed sbd example

### DIFF
--- a/man/SAPHanaSR_basic_cluster.7
+++ b/man/SAPHanaSR_basic_cluster.7
@@ -177,7 +177,7 @@ Example for a priority fencing disk-based SBD resource.
 .br
 primitive rsc_stonith_sbd stonith:external/sbd \\
 .br
- params pcmk_delay_base=15 \\
+ params pcmk_delay_max=15 \\
 .br
 property cib-bootstrap-options: \\
 .br


### PR DESCRIPTION
Hi,
just a fix for man page SAPHanaSR_basic_cluster.7: fixed sbd example.
Might go into next maint. update.
Regards,
Lars