### PR TITLE
write LOG message before RA initialization for better observability

### DIFF
--- a/ra/SAPHana
+++ b/ra/SAPHana
@@ -2939,6 +2939,8 @@ case "$ACTION" in
                     exit $OCF_SUCCESS;;
     *);;
 esac
+
+super_ocf_log info "RA ==== initialization (${SAPHanaVersion:-}) (${SECONDS}s)===="
 saphana_init
 
 if ! ocf_is_root

--- a/ra/SAPHanaTopology
+++ b/ra/SAPHanaTopology
@@ -1208,6 +1208,8 @@ case "$ACTION" in
                     exit $OCF_SUCCESS;;
     *);;
 esac
+
+super_ocf_log info "RA ==== initialization (${SAPHanaTopologyVersion:-}) (${SECONDS}s)===="
 sht_init
 
 if ! ocf_is_root


### PR DESCRIPTION
```
SAPHanaTopology(rsc_SAPHanaTopology_SID_HDB00)[26112]: INFO: RA ==== initialization (0.162.3) (0s)====
SAPHanaTopology(rsc_SAPHanaTopology_SID_HDB00)[26112]: INFO: DEC: site=Site40, mode=syncmem, MAPPING=host1, hanaRemoteHost=host1
SAPHanaTopology(rsc_SAPHanaTopology_SID_HDB00)[26112]: INFO: RA ==== begin action monitor_clone (0.162.3) (4s)====
SAPHanaTopology(rsc_SAPHanaTopology_SID_HDB00)[26112]: INFO: RA ==== end action monitor_clone with rc=0 (0.162.3) (6s)====

SAPHana(rsc_SAPHana_SID_HDB00)[26367]: INFO: RA ==== initialization (0.162.3) (0s)====
SAPHana(rsc_SAPHana_SID_HDB00)[26367]: INFO: RA ==== begin action monitor_clone (0.162.3) (1s)====
SAPHana(rsc_SAPHana_SID_HDB00)[26367]: INFO: DEC: hana_SID_site_srHook_Site40=SOK
SAPHana(rsc_SAPHana_SID_HDB00)[26367]: INFO: DEC: Finally get_SRHOOK()=SOK
SAPHana(rsc_SAPHana_SID_HDB00)[26367]: INFO: DEC: hana_SID_site_srHook_Site40=SOK
SAPHana(rsc_SAPHana_SID_HDB00)[26367]: INFO: DEC: Finally get_SRHOOK()=SOK
SAPHana(rsc_SAPHana_SID_HDB00)[26367]: INFO: DEC: secondary with sync status SOK ==> possible takeover node
SAPHana(rsc_SAPHana_SID_HDB00)[26367]: INFO: DEC: hana_SID_site_srHook_Site40=SOK
SAPHana(rsc_SAPHana_SID_HDB00)[26367]: INFO: DEC: Finally get_SRHOOK()=SOK
SAPHana(rsc_SAPHana_SID_HDB00)[26367]: INFO: DEC: saphana_monitor_secondary: scoring_crm_master(4:S:master1:master:worker:master,SOK)
SAPHana(rsc_SAPHana_SID_HDB00)[26367]: INFO: DEC: scoring_crm_master: roles(4:S:master1:master:worker:master) are matching pattern ([234]*:S:[^:]*:master)
SAPHana(rsc_SAPHana_SID_HDB00)[26367]: INFO: DEC: scoring_crm_master: sync(SOK) is matching syncPattern (SOK)
SAPHana(rsc_SAPHana_SID_HDB00)[26367]: INFO: DEC: scoring_crm_master: set score 100
SAPHana(rsc_SAPHana_SID_HDB00)[26367]: INFO: RA ==== end action monitor_clone with rc=0 (0.162.3) (5s)====

```