### PR TITLE
changes to the spec and changes files for the next maintenance update 1.2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <div align="center"> SAPHanaSR-angi - SAP HANA System Replication <br> A New Generation Interface </div>
+# <div align="center"> SAPHanaSR-angi - SAP HANA System Replication <br> A Next Generation Interface </div>
 
 The SUSE resource agents to control the SAP HANA database in system replication setups
 
@@ -7,11 +7,12 @@ The SUSE resource agents to control the SAP HANA database in system replication 
 
 ## Introduction
 
-SAPHanaSR-angi provides an automatic failover between SAP HANA nodes with configured System Replication in HANA. Currently Scale-Up setups are targeted.
+SAPHanaSR-angi is "SAP HANA SR - An Next Generation Interface" for SUSE high availabilty clusters to manage SAP HANA databases with system replication.
+It provides an automatic failover between SAP HANA nodes with configured System Replication in HANA. The current version of SAPHanaSR-angi is targeting SAP HANA SR scale-up and scale-out setups.
 
-CIB attributes are not backward compatible between SAPHanaSR-angi and SAPHanaSR. So there is currently no easy migration path.
+CIB attributes are not backward compatible between SAPHanaSR-angi and the classic SAPHanaSR. Nevertheless, SAPHanaSR and SAPHanaSR-ScaleOut can be upgraded to SAPHanaSR-angi by following the documented procedure.
 
-This technology is included in the SUSE Linux Enterprise Server for SAP Applications 15 (as technology preview), via the RPM package with the same name.
+This technology is included in the SUSE Linux Enterprise Server for SAP Applications 15, via the RPM package with the same name.
 
 System replication will help to replicate the database data from one node to another node in order to compensate for database failures. With this mode of operation, internal SAP HANA high-availability (HA) mechanisms and the Linux cluster have to work together.
 
@@ -27,8 +28,12 @@ Only if the HANA landscape status indicates that HANA can not recover from the f
 An important task of the resource agent is to check the synchronisation status of the two SAP HANA databases. If the synchronisation is not "SOK", then the
 cluster avoids to take over to the secondary side, if the primary fails. This is to improve the data consistency.
 
-For more information, refer to the ["Supported High Availability Solutions by SLES for SAP Applications](https://documentation.suse.com/sles-sap/sap-ha-support/html/sap-ha-support/article-sap-ha-support.html) and all the manual pages shipped with the package.
+For more information, refer to the ["Supported High Availability Solutions by SLES for SAP Applications"](https://documentation.suse.com/sles-sap/sap-ha-support/html/sap-ha-support/article-sap-ha-support.html) and all the manual pages shipped with the package.
 
+For SAP HANA Databases in System Replication only the listed scenarios at ["Supported High Availability Solutions by SLES for SAP Applications"](https://documentation.suse.com/sles-sap/sap-ha-support/html/sap-ha-support/article-sap-ha-support.html) are supported. For any scenario not matching the scenarios named or referenced in our setup guides please contact SUSE services.
+
+The following SUSE blog series gives a good overview about running SAP HANA in System Replication in the SUSE cluster:
+["towardszerodowntime"](https://www.suse.com/c/tag/towardszerodowntime/)
 
 ## File structure of installed package
 

--- a/SAPHanaSR-angi.changes
+++ b/SAPHanaSR-angi.changes
@@ -1,10 +1,46 @@
 -------------------------------------------------------------------
+Fri Oct 18 07:55:34 UTC 2024 - abriel@suse.com
+
+- Version bump to 1.2.9
+  * add SAPHanaSR-alert-fencing, an alert agent for cluster fencing
+    alerts.
+  * enhance SAPHanaController with the feature ON_FAIL_ACTION=fence
+    This is part of the 'FAST-STOP' feature of the resource agents.
+    (jsc#SAPSOL-196)
+  * Improve handling of timeout return values for the resource
+    agents
+  * SAPHanaSR-showAttr - adding new option 'sitelist' and new
+    output format 'csv' and 'cache'
+  * new man page:
+    SAPHanaSR-alert-fencing.8
+  * update man pages:
+    SAPHanaSR.7
+    SAPHanaSR-ScaleOut.7
+    SAPHanaSR_basic_cluster.7
+    SAPHanaSR-ScaleOut_basic_cluster.7
+    SAPHanaSR_maintenance_examples.7
+    SAPHanaSR_upgrade_to_angi.7
+    SAPHanaSR-upgrade-to-angi-demo.8
+    ocf_suse_SAPHana.7
+    ocf_suse_SAPHanaController.7
+    ocf_suse_SAPHanaTopology.7
+    ocf_suse_SAPHanaFilesystem.7
+    susChkSrv.py.7
+    susCostOpt.py.7
+    SAPHanaSR-showAttr.8
+
+- add additional requires for SLE16
+  /usr/bin/sudo and /usr/bin/logger
+
+-------------------------------------------------------------------
 Tue May  7 17:55:56 UTC 2024 - abriel@suse.com
 
 - Version bump to 1.2.7
   * package SAPHanaSR-angi and SAPHanaFilesystem RA are now
     in state 'supported'
+    (jsc#PED-6403)
   * add feature HANA 'FAST-STOP' and parameter 'ON_FAIL_ACTION'
+    (jsc#SAPSOL-133)
   * new demo script SAPHanaSR-upgrade-to-angi-demo
   * added crm config examples
   * susHanaSR.py adapt syntax

--- a/SAPHanaSR-angi.spec
+++ b/SAPHanaSR-angi.spec
@@ -21,7 +21,7 @@ License:        GPL-2.0
 Group:          Productivity/Clustering/HA
 AutoReqProv:    on
 Summary:        Resource agents to control the HANA database in system replication setup
-Version:        1.2.8
+Version:        1.2.9
 Release:        0
 Url:            https://www.suse.com/c/fail-safe-operation-of-sap-hana-suse-extends-its-high-availability-solution/
 
@@ -41,6 +41,10 @@ Requires:       crmsh >= 4.4.0
 Requires:       crmsh-scripts >= 4.4.0
 Requires:       python3
 Requires:       /usr/bin/xmllint
+%if 0%{?suse_version} >= 1600
+Requires:       /usr/bin/sudo
+Requires:       /usr/bin/logger
+%endif
 BuildRequires:  resource-agents >= 4.1.0
 BuildRequires:  crmsh
 BuildRequires:  crmsh-scripts

--- a/SAPHanaSR-tester.changes
+++ b/SAPHanaSR-tester.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Oct 18 09:36:32 UTC 2024 - abriel@suse.com
+
+- update to version 1.2.14
+
+-------------------------------------------------------------------
 Mon Nov 13 11:43:23 UTC 2023 - Fabian Herschel <fabian.herschel@suse.com>
 
 - version 1.2.4 as base for test package

--- a/SAPHanaSR-tester.spec
+++ b/SAPHanaSR-tester.spec
@@ -73,13 +73,13 @@ mkdir -p %{buildroot}%{_mandir}/man8
 
 # test engine itself
 mkdir -p %{buildroot}/usr/lib/%{name}
-install -m 0755 test/SAPHanaSR-* %{buildroot}/usr/bin
-install -m 0644 test/saphana_sr_test.py %{buildroot}/usr/lib/%{name}
+install -m 0755 test/tester/SAPHanaSR-* %{buildroot}/usr/bin
+install -m 0644 test/tester/saphana_sr_test.py %{buildroot}/usr/lib/%{name}
 
 # test help programs, test loops and test calls
-install -m 0755 test/cs_* %{buildroot}/usr/bin
-install -m 0755 test/callTest* %{buildroot}/usr/bin
-install -m 0755 test/loopTests* %{buildroot}/usr/bin
+install -m 0755 test/bin/cs_* %{buildroot}/usr/bin
+install -m 0755 test/bin/callTest* %{buildroot}/usr/bin
+install -m 0755 test/bin/loopTests* %{buildroot}/usr/bin
 install -m 0755 test/bin/sct_* %{buildroot}/usr/bin
 
 # client files


### PR DESCRIPTION
some changes needed for the next update
I skipped the version 1.2.8 as this was a test version for SAP internal tests and we need to be sure to not confuse the supported package versions.
Tag for the new version will be set after test of the package.