### PR TITLE
SAPHanaSR-upgrade-to-angi-demo: zypper se -t package

### DIFF
--- a/test/SAPHanaSR-upgrade-to-angi-demo
+++ b/test/SAPHanaSR-upgrade-to-angi-demo
@@ -568,7 +568,7 @@ function f_check-prereq() {
 		echo "ERROR: Package SAPHanaSR-tester-client installed."
 		pre_rc=9
 	fi
-	rmt=$(zypper se $RPMNEW 2>/dev/null | grep -c $RPMNEW)
+	rmt=$(zypper se -t package $RPMNEW 2>/dev/null | grep -c $RPMNEW)
 	if [ $rmt != 1 ]; then
 		echo "ERROR: Can not find $RPMNEW in software channels."
 		pre_rc=9


### PR DESCRIPTION
Hi,
fix for SAPHanaSR-upgrade-to-angi. The fix already has been in main.
Might go into the next maintenance update.
Regards,
Lars