### PR TITLE
SAPHanaSR-upgrade-to-angi-demo: removed on-fail action

### DIFF
--- a/man/SAPHanaSR-showAttr.8
+++ b/man/SAPHanaSR-showAttr.8
@@ -1,6 +1,6 @@
-.\" Version: 0.162.1
+.\" Version: 0.162.3
 .\"
-.TH SAPHanaSR-showAttr 8 "24 Jan 2024" "" "SAPHanaSR"
+.TH SAPHanaSR-showAttr 8 "07 Feb 2025" "" "SAPHanaSR"
 .\"
 .SH NAME
 SAPHanaSR-showAttr \- Shows Linux cluster attributes for SAP HANA system replication.
@@ -482,7 +482,7 @@ The virtual hostname is used by the HANA instance instead of Linux hostname.
 The node attribute hana_<sid>_vhost is set by SAPHanaTopology, according to
 the running HANA. The attribute is used by the SAPHanaController or SAPHana
 resource agent for setting up system replication.
-See also the fields Hosts and remoteHost. SAPHanaToplogy needs the SAPHOSTAGENT
+See also the fields Hosts and remoteHost. SAPHanaTopology needs the SAPHOSTAGENT
 to map from the local hostname to the HANA virtual hostname.
 .\" TODO details, see HANA global.ini
 .\"
@@ -584,7 +584,7 @@ F.Herschel, L.Pinne.
 .br
 (c) 2015-2017 SUSE Linux GmbH, Germany.
 .br
-(c) 2018-2024 SUSE LLC
+(c) 2018-2025 SUSE LLC
 .br
 SAPHanaSR-showAttr comes with ABSOLUTELY NO WARRANTY.
 .br

--- a/man/SAPHanaSR.7
+++ b/man/SAPHanaSR.7
@@ -1,6 +1,6 @@
 .\" Version: 0.162.3
 .\"
-.TH SAPHanaSR 7 "08 Jan 2025" "" "SAPHanaSR"
+.TH SAPHanaSR 7 "07 Feb 2025" "" "SAPHanaSR"
 .\"
 .SH NAME
 SAPHanaSR \- Tools for automating SAP HANA system replication in scale-up setups.
@@ -292,6 +292,7 @@ memory can be used, as long as they are transparent to SUSE HA.
 .PP
 23. The SAP HANA site name is from 2 up to 32 characters long. It starts with a
 character or number. Subsequent characters may contain dash and underscore.
+However, underscore should be avoided.
 .PP
 24. The SAPHanaController RA, the SUSE HA cluster and several SAP components
 need read/write access and sufficient space in the Linux /tmp filesystem.

--- a/test/SAPHanaSR-upgrade-to-angi-demo
+++ b/test/SAPHanaSR-upgrade-to-angi-demo
@@ -12,7 +12,7 @@
 #
 # define parameters and functions
 #
-VERSION="2025-01-20 0.3b"
+VERSION="2025-02-04 0.3d"
 DRYRUN=yes
 # TODO DRYRUN=no
 EXE=$(basename $0)
@@ -55,7 +55,7 @@ clone @@clntop@@ rsc_SAPHanaTop_@@sid@@_HDB@@ino@@ \
 CIB_CLNTMP_FIL="#
 primitive rsc_SAPHanaFil_@@sid@@_HDB@@ino@@ ocf:suse:SAPHanaFilesystem \
   op start interval=0 timeout=10 \
-  op stop interval=0 timeout=20 on-fail=fence \
+  op stop interval=0 timeout=20 \
   op monitor interval=120 timeout=120 \
   params SID=@@sid@@ InstanceNumber=@@ino@@
 #

--- a/test/SAPHanaSR-upgrade-to-angi-demo
+++ b/test/SAPHanaSR-upgrade-to-angi-demo
@@ -55,7 +55,7 @@ clone @@clntop@@ rsc_SAPHanaTop_@@sid@@_HDB@@ino@@ \
 CIB_CLNTMP_FIL="#
 primitive rsc_SAPHanaFil_@@sid@@_HDB@@ino@@ ocf:suse:SAPHanaFilesystem \
   op start interval=0 timeout=10 \
-  op stop interval=0 timeout=20 \
+  op stop interval=0 timeout=20 on-fail=fence \
   op monitor interval=120 timeout=120 \
   params SID=@@sid@@ InstanceNumber=@@ino@@
 #


### PR DESCRIPTION
Hi,
SAPHanaSR-upgrade-to-angi-demo needs a fix on the SAPHanaFilesystem resource config. The on-fail=fence is wrong.
Might go into next maintenance update.
Regards,
Lars