### PR TITLE
saphana_sr_tools.py - restore proper field separator

### DIFF
--- a/tools/saphana_sr_tools.py
+++ b/tools/saphana_sr_tools.py
@@ -572,7 +572,7 @@ class HanaStatus():
         """
         time_string = ""
         quote = ''
-        fs = ';' # field separator
+        fs = ':' # field separator
         short = False
         if 'quote' in kargs:
             quote = kargs['quote']


### PR DESCRIPTION
In 2ca27838fbe0677c9a03bc9d90424d471fbf9997 the literal ':' used as field separator was changed to a variable set to ';'. I could not find any documentation for this change so I assumed it was a typo which leads to processing fencing not being able to process a cache file in https://github.com/SUSE/SAPHanaSR/blob/7420b6aa95ca804b6c0ba62a1267cd18ece956bc/alert/SAPHanaSR-alert-fencing#L38

Either you need to merge this change that restores the separator, or you need to fix the above `awk` command with a matching separator option.

Fixes the current issue in bsc#1250160.