### PR TITLE
Angi devel - express fixes

### DIFF
--- a/man/SAPHanaSR-showAttr.8
+++ b/man/SAPHanaSR-showAttr.8
@@ -1,6 +1,6 @@
 .\" Version: 1.2 
 .\"
-.TH SAPHanaSR-showAttr 8 "14 Aug 2025" "" "SAPHanaSR"
+.TH SAPHanaSR-showAttr 8 "07 Oct 2025" "" "SAPHanaSR"
 .\"
 .SH NAME
 .\"
@@ -389,7 +389,7 @@ Value: [ master | worker | slave | standby | shtdown ]
 .PP
 .\"scale-up:
 .\"Value: [ 150 | 140 | 100 | 90 | 80 | 60 | 10 | 0 | -1 | -INFINITY ]
-Value: [ 150 | 145 | 140 | 115 | 110 | 100 | 90 | 80 | 70 | 60 | 10 | 5 | 0 | -1 | -9000 | -10000 | -12200 | -22100 | -22200 | -32300 | -33333 | -INFINITY ]
+Value: [ 150 | 145 | 140 | 115 | 110 | 101 | 100 | 90 | 80 | 70 | 60 | 10 | 5 | 0 | -1 | -9000 | -10000 | -12200 | -22100 | -22200 | -32300 | -33333 | -INFINITY ]
 .PP
 This is a variable of the SAPHanaController resource agent. It is calculated
 based on an internal scoring table. A value of 150 should cause the Linux cluster promoting

--- a/ra/saphana-controller-common-lib
+++ b/ra/saphana-controller-common-lib
@@ -361,13 +361,14 @@ function saphana_init_scoring_tables() {
     )
     # shellcheck disable=SC2034
     SCORING_TABLE_PREFERRED_SITE_TAKEOVER_SO=(
-       "[234]   P master[123]:master            .*          150 'not described yet'"
-       "[234]   P master[123]                   .*          140 'not described yet'"
-       "[234]   P master[123]:slave:.*:standby  .*          115 'not described yet'"
-       "[234]   P master[123]:slave             .*          110 'not described yet'"
-       "[015]   P master[123]:                  .*           70 'not described yet'"
-       "[0-9]   P master[123]:*:standby         .*           60 'not described yet'"
-       "[0-9]   P slave:                        .*       -10000 'not described yet'"
+       "[234]   P master[123]:master            .*          150 'primary - running, active master nameserver role'"
+       "[234]   P master[123]                   .*          140 'primary - running, master nameserver candidate'"
+       "[234]   P master[123]:slave:.*:standby  .*          115 'primary - running, master nameserver candidate, standby role'"
+       "[234]   P master[123]:slave             .*          110 'primary - running, master nameserver candidate, no standby role'"
+       "[015]   P master[123]:                  .*           70 'primary - not running, master nameserver candidate'"
+       "[0-9]   P master[123]:*:standby         .*           60 'primary - any status, master nameserver candidate, standby role'"
+       "[234]   P slave:slave                   .*          101 'primary - any running status, slave nameserver role; delay possible takeover on secondary master till primary is completely down'"
+       "[01]    P slave:                        .*       -10000 'not described yet'"
        "0       P [^:]*:[?:-]                   .*         NULL 'primary - lss=0 defect, keep scoring'"
        "124     P [^:]*:[?:-]                   .*         NULL 'primary - lss=124 defect, keep scoring'"
        "[234]   S master[123]:master            SOK         100 'not described yet'"

--- a/ra/saphana-controller-lib
+++ b/ra/saphana-controller-lib
@@ -1815,7 +1815,7 @@ function saphana_monitor_clone() {
                 super_ocf_log info "RA ON_FAIL_ACTION != 'fence'"
             fi
         else
-            super_ocf_log info "RA gFullRole=$gFullRole does not match '^1:P:'"
+            super_ocf_log info "RA gFullRole=$gFullRole - No FAST-STOP needed"
         fi
         super_ocf_log info "DEC: scoring_crm_promote **11**"
         scoring_crm_promote "$gFullRole" "$gSrHook"
@@ -2041,7 +2041,7 @@ function saphana_demote_clone() {
             super_ocf_log info "RA ON_FAIL_ACTION != 'fence'"
         fi
     else
-        super_ocf_log info "RA gFullRole=$gFullRole does not match '^1:P:'"
+        super_ocf_log info "RA gFullRole=$gFullRole - No FAST-STOP needed"
     fi
     super_ocf_log info "ACT: Demoted $SID-$InstanceName."
     super_ocf_log info "FLOW ${FUNCNAME[0]} rc=$rc"

--- a/test/json/angi-ScaleOut/defaults.json
+++ b/test/json/angi-ScaleOut/defaults.json
@@ -63,7 +63,7 @@
         "pWorkerUp": [
             "clone_state == DEMOTED",
             "roles == slave:slave:worker:slave",
-            "score == -10000"
+            "score == 101"
         ],
         "sWorkerUp": [
             "clone_state == DEMOTED",

--- a/test/json/angi-ScaleUp/kill_secn_nameserver.json
+++ b/test/json/angi-ScaleUp/kill_secn_nameserver.json
@@ -40,7 +40,7 @@
             ],
             "sHost": [
                 "clone_state == DEMOTED",
-                "roles ~ (::::|master1:master:worker:master)",
+                "roles ~ (::::|master1::worker:)",
                 "score ~ (100|-INFINITY)"
             ]
         },

--- a/tools/SAPHanaSR-showAttr
+++ b/tools/SAPHanaSR-showAttr
@@ -182,15 +182,15 @@ if __name__ == "__main__":
             myHana.print_dic_as_path(myHana.site_dict, "site", "Site", quote='"')
             myHana.print_dic_as_path(myHana.host_dict, "host", "Host", quote='"')
         elif oformat in {"cache"}:
-            myHana.print_dic_as_csv(myHana.host_dict, "host", "Host", quote='', short=True)
+            myHana.print_dic_as_csv(myHana.host_dict, "host", "Host", quote='', short=True, fs=':')
         elif oformat in {"csv"}:
-            ts = myHana.ts
-            s_cib_time_fmt = datetime.datetime.utcfromtimestamp(int(ts))
-            t_str = s_cib_time_fmt.strftime('%Y-%m-%dT%H:%M:%S')
-            myHana.print_dic_as_csv(myHana.glob_dict, "global", "Global", quote='', ts=t_str)
-            myHana.print_dic_as_csv(myHana.res_dict, "resource", "Resource", quote='')
-            myHana.print_dic_as_csv(myHana.site_dict, "site", "Site", quote='')
-            myHana.print_dic_as_csv(myHana.host_dict, "host", "Host", quote='')
+            cib_time=0
+            if 'cib-time' in myHana.glob_dict["global"]:
+                cib_time = myHana.glob_dict["global"]['cib-time']
+            myHana.print_dic_as_csv(myHana.glob_dict, "global", "Global", quote='', ts=cib_time)
+            myHana.print_dic_as_csv(myHana.res_dict, "resource", "Resource", quote='', ts=cib_time)
+            myHana.print_dic_as_csv(myHana.site_dict, "site", "Site", quote='', ts=cib_time)
+            myHana.print_dic_as_csv(myHana.host_dict, "host", "Host", quote='', ts=cib_time)
     if len(cib_file_list) == 0:
         print("ERROR: No cib files found")
         sys.exit(2)

--- a/tools/saphana_sr_tools.py
+++ b/tools/saphana_sr_tools.py
@@ -572,7 +572,7 @@ class HanaStatus():
         """
         time_string = ""
         quote = ''
-        fs = ';' # field separator
+        fs = kargs.get("fs", ';')
         short = False
         if 'quote' in kargs:
             quote = kargs['quote']


### PR DESCRIPTION
bsc#1250160 - fixing possible lss124 dual primary situations
The planned next version for SAPHanaSR-angi

* works for SAP HANA Scale-Out WITHOUT SAP HANA standby nodes (host auto-failover is off)
* needs on sle15sp4 at least crmsh 4.4.2+20250526.46896f4
* has been tested in our Lab for
  - SAPHanaSR-angi ScaleUp Progressive (sbd fencing) on sle15sp7
  - SAPHanaSR-angi ScaleOut Progressive (diskless sbd fencing) on sle15sp4
* includes a change for the ScaleOut prefer site take over scoring table - the SAP HANA primary slave nodes are now scored with 101 instead of -10.000

This PR fixes the 

* ScaleUp and ScaleOut: the colon/semicolon bug in the tools of SAPHanaSR-angi
* ScaleOut: a possible short-time race condition during fencing of multiple nodes with begin of promoting the secondary site