### PR TITLE
Bsc1261560 execution order

### DIFF
--- a/srHook/global.ini_susTkOver
+++ b/srHook/global.ini_susTkOver
@@ -2,7 +2,7 @@
 provider = susTkOver
 path = /usr/share/SAPHanaSR-angi
 sustkover_timeout = 30
-execution_order = 1
+execution_order = 2
 
 [trace]
 ha_dr_sustkover = info

--- a/srHook/susChkSrv.py
+++ b/srHook/susChkSrv.py
@@ -11,7 +11,7 @@ To use this HA/DR hook provide please add the following lines (or similar) to yo
     [ha_dr_provider_suschksrv]
     provider = susChkSrv
     path = /usr/share/SAPHanaSR
-    execution_order = 2
+    execution_order = 3
     action_on_lost = kill | stop | ignore | fence (attr is currently not implemented)
     stop_timeout = 20
     # timeout = timeout-in-seconds (currently not implemented)

--- a/srHook/susTkOver.py
+++ b/srHook/susTkOver.py
@@ -12,7 +12,7 @@ To use this HA/DR hook provide please add the following lines (or similar) to yo
     provider = susTkOver
     path = /usr/share/SAPHanaSR
     sustkover_timeout = 30
-    execution_order = 1
+    execution_order = 2
 
     [trace]
     ha_dr_sustkover = info


### PR DESCRIPTION
This PR is to align the best practices with the HADR-Python Hooks (inline comments) and the configuration examples to have the same execution order. We now use the same execution orders as used in https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-scaleout-perfopt-15/index.html#id-implementing-sustkover-py-for-pretakeover.