### PR TITLE
Takeover maintenance check: be explicit in resource match

### DIFF
--- a/tools/SAPHanaSR-hookHelper
+++ b/tools/SAPHanaSR-hookHelper
@@ -92,8 +92,8 @@ sid_is_in_cluster() {
 # check, if the multi-state resource is in maintenance
 chk_msres_maintenance() {
     mmaint="false"
-    # get promotable clone resource name (select first promotable=true clone, then by provider=SUSE and SID)
-    rnameNew=$(xmllint -xpath "string(//clone/meta_attributes/nvpair[@name='promotable' and @value='true']/../../primitive[@class='ocf' and @provider='suse']/instance_attributes/nvpair[@name='SID' and @value='$RSID']/../../../@id)" "$cibtmp")
+    # get promotable clone resource name (select by type=SAPHanaController and SID)
+    rnameNew=$(xmllint -xpath "string(//clone/primitive[@class='ocf' and @type='SAPHanaController']/instance_attributes/nvpair[@name='SID' and @value='$RSID']/../../../@id)" "$cibtmp")
     if [ -n "$rnameNew" ]; then
         # check for maintenance
         mmaint=$(xmllint -xpath "string(//clone[@id='$rnameNew']/meta_attributes/nvpair[@name='maintenance']/@value)" "$cibtmp")


### PR DESCRIPTION
The current xpath identifies the `SAPHanaController` clone indirectly via the `promotable=true` meta-attribute and the provider path. Using `@type='SAPHanaController'` directly is more explicit and resilient - it targets the resource by what it is rather than by a cluster topology characteristic and resource agent provider path it happens to have. It makes the intent of the query self-evident and immune to false matches if the cluster configuration evolves.