### PR TITLE
hookHelper: also check cluster-wide maintenance in checkTakeover

### DIFF
--- a/srHook/susTkOver.py
+++ b/srHook/susTkOver.py
@@ -108,7 +108,7 @@ try:
                                      f" because cluster is not working properly cmdrc={cmdrc}")
                     sra_rc = 0
                 elif cmdrc == 5:
-                    # multi-state resource in maintenance, permit takeover
+                    # multi-state resource or cluster in maintenance, permit takeover
                     self.tracer.info(f"{self.__class__.__name__}.{method}()"
                                      " permit non-cluster action sr_takeover()"
                                      f" because found cluster maintenance settings (cmdrc={cmdrc})")
@@ -123,7 +123,7 @@ try:
                 elif cmdrc == 4:
                     # block takeover
                     # sr_takeover attribute not found or not set to 'T'
-                    # and multi-state ressource is NOT in maintenance
+                    # and multi-state resource or cluster is NOT in maintenance
                     self.tracer.info(f"{self.__class__.__name__}.{method}()"
                                      f" reject non-cluster action sr_takeover() cmdrc={cmdrc}")
                     try:

--- a/tools/SAPHanaSR-hookHelper
+++ b/tools/SAPHanaSR-hookHelper
@@ -9,15 +9,15 @@
 # Helper script for HA/DR hooks
 # currently implemented use case are 'checkTakeover' and 'fenceMe'
 
-# For now we only check the maintenance mode of the multi-state ressource (as descibed in the official supported maintenance procedure described in man page SAPHanaSR_maitenance_examples(7) - EXAMPLES: * Perform an SAP HANA take-over by using SAP tools.
+# We check the maintenance mode of the multi-state resource (as described in the official supported maintenance procedure in man page SAPHanaSR_maintenance_examples(7) - EXAMPLES: * Perform an SAP HANA take-over by using SAP tools) and additionally the cluster-wide maintenance mode.
 
 # Definition of the exit codes returned to the hook scripts:
 # for the current use case 'checkTakeover' it translate to
 #  0 - OK
 #    - takeover requested by cluster, permit takeover
 #  4 - block takeover (sr_takeover attribute not found or not set to 'T' and
-#      multi-state ressource is NOT in maintenance)
-#  5 - multi-state resource in maintenance, permit takeover
+#      multi-state resource and cluster are NOT in maintenance)
+#  5 - multi-state resource or cluster in maintenance, permit takeover
 #  6 - cluster not available, permit takeover
 #  7 - given SID not configured in the cluster, permit takeover
 # 99 - unknown cluster command error, permit takeover
@@ -87,6 +87,15 @@ sid_is_in_cluster() {
     else
         return 0
     fi
+}
+
+# check, if the whole cluster is in maintenance mode
+chk_cluster_maintenance() {
+    cmaint=$(xmllint -xpath "string(//crm_config/cluster_property_set/nvpair[@name='maintenance-mode']/@value)" "$cibtmp")
+    if [ -z "$cmaint" ]; then
+        cmaint="false"
+    fi
+    echo "$cmaint"
 }
 
 # check, if the multi-state resource is in maintenance
@@ -232,15 +241,16 @@ case "$USECASE" in
             chk_takeover_attr; rc=$?
             if [ "$rc" == 4 ]; then
                 # sr_takeover attribute not found or not set to 'T'
-	        # check, if multi-state ressource is in maintenance
-                maint=$(chk_msres_maintenance)
-                if [ "$maint" == "true" ]; then
-                    # permit sr_takeover, because multi-state ressource is
-                    # in maintenance
-	            rc=5
+                # check, if multi-state resource or cluster is in maintenance
+                msres_maint=$(chk_msres_maintenance)
+                cluster_maint=$(chk_cluster_maintenance)
+                if [ "$msres_maint" == "true" ] || [ "$cluster_maint" == "true" ]; then
+                    # permit sr_takeover, because multi-state resource or cluster
+                    # is in maintenance
+                    rc=5
                 else
                     # block takeover, because sr_takeover attribute not found or not
-                    # set to 'T' and multi-state ressource is NOT in maintenance
+                    # set to 'T' and multi-state resource and cluster are NOT in maintenance
                     rc=4
                 fi
             fi


### PR DESCRIPTION
## Problem

`checkTakeover` permitted a manual takeover when the promotable clone resource had `maintenance=true`, but not when the whole cluster was in maintenance mode (`maintenance-mode=true` cluster property).

The cluster in maintenance-mode is a similar logic as the multi-state resource in maintenance and should allow a takeover.

## Solution

Add `chk_cluster_maintenance()` to `SAPHanaSR-hookHelper`. It reads the cluster-wide `maintenance-mode` property from the CIB snapshot already fetched by `checkTakeover`, adding no extra cluster calls.

The takeover is now permitted (rc=5) when either condition holds:
- multi-state resource has `maintenance=true`
- cluster has `maintenance-mode=true`

Also fix a few typos in comments in the context of this change.

## Test

Tested in a live cluster with
- `maintenance-mode=true` -> permits takeover
- `maintenance-mode=false` -> blocks takeover
- `maintenance-mode` absent -> blocks takeover

Verified that `maintenance=true` on the promotable resource alone still works.

In both cases - promotable resource or cluster maintenance - the promotable resource must be refreshed after the takeover. I see no difference in the behavior.